### PR TITLE
remove leftover symlink

### DIFF
--- a/news/64-remove-symlink
+++ b/news/64-remove-symlink
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Remove lingering `codesign` symlink in `$PREFIX/bin` (macOS only). (#54)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -29,3 +29,7 @@ python src/licenses.py \
 
 # clean up .pyc files that pyinstaller creates
 rm -rf "$PREFIX/lib"
+
+if [[ $target_platform == osx-* ]]; then
+  rm "$BUILD_PREFIX/bin/codesign"
+fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,7 @@ test:
     - tests
   commands:
     - pytest -vv
+    - test ! -f {{ PREFIX }}/bin/codesign  # [osx]
 
 about:
   home: https://github.com/conda/conda-standalone

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ test:
     - tests
   commands:
     - pytest -vv
-    - test ! -f {{ PREFIX }}/bin/codesign  # [osx]
+    - test ! -e {{ PREFIX }}/bin/codesign  # [osx]
 
 about:
   home: https://github.com/conda/conda-standalone


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Identified in https://github.com/conda-forge/conda-standalone-feedstock/pull/69#issuecomment-1893873734.

This `codesign` symlink should not make it to the final package. It does because there's no `requirements/host` key, so `conda-build` defaults to `conda-build v2` behaviour, where BUILD_PREFIX == PREFIX.

We tried adding an empty `host`, but that complicates the build script with `SP_DIR` and other changes. It's just easier to remove the symlink once we are done with the PyInstaller job.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
