### PR TITLE
Add workaround to prevent crash on Windows when the `SSLKEYLOGFILE` environment variable is set

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           name: conda-standalone-${{ matrix.subdir }}
           path: ${{ runner.temp }}/bld/${{ matrix.subdir }}/conda-standalone-*.*
-    
+
       - name: Upload package to anaconda.org
         shell: bash -el {0}
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,8 @@ jobs:
             subdir: osx-arm64
           - os: windows-latest
             subdir: win-64
+    env:
+      PYTHONUNBUFFERED: "1"
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: conda-incubator/setup-miniconda@v3
@@ -53,6 +55,12 @@ jobs:
           CONDA_BLD_PATH: ${{ runner.temp }}/bld
         run: conda build recipe --override-channels -c conda-forge
 
+      - uses: actions/upload-artifact@v4
+        if: github.event_name == 'pull_request'
+        with:
+          name: conda-standalone-${{ matrix.subdir }}
+          path: ${{ runner.temp }}/bld/${{ matrix.subdir }}/conda-standalone-*.*
+    
       - name: Upload package to anaconda.org
         shell: bash -el {0}
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -72,7 +80,7 @@ jobs:
             --label="${ANACONDA_ORG_LABEL}" \
             ${CONDA_BLD_PATH}/${{ matrix.subdir }}/conda-standalone-*.*
           echo "Uploaded the following files:"
-          basename -a ${CONDA_BLD_PATH}/pkgs/${{ matrix.subdir }}/conda-standalone-*.*
+          basename -a ${CONDA_BLD_PATH}/${{ matrix.subdir }}/conda-standalone-*.*
 
           echo "Use this command to try out the build:"
           echo "  conda install -c ${ANACONDA_ORG_CHANNEL}/label/${ANACONDA_ORG_LABEL} conda-standalone"

--- a/news/89-openssl-applink
+++ b/news/89-openssl-applink
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Add workaround to prevent crash on Windows when the `SSLKEYLOGFILE` environment variable is set. (#86 via #89).
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/src/entry_point.py
+++ b/src/entry_point.py
@@ -12,6 +12,11 @@ import sys
 from multiprocessing import freeze_support
 from pathlib import Path
 
+if "SSLKEYLOGFILE" in os.environ:
+    # This causes a crash with requests 2.32+
+    # See https://github.com/conda/conda-standalone/issues/86
+    del os.environ["SSLKEYLOGFILE"]
+
 
 def _create_dummy_executor(*args, **kwargs):
     "use this for debugging, because ProcessPoolExecutor isn't pdb/ipdb friendly"

--- a/src/entry_point.py
+++ b/src/entry_point.py
@@ -12,8 +12,9 @@ import sys
 from multiprocessing import freeze_support
 from pathlib import Path
 
-if "SSLKEYLOGFILE" in os.environ:
-    # This causes a crash with requests 2.32+
+if os.name == "nt" and "SSLKEYLOGFILE" in os.environ:
+    # This causes a crash with requests 2.32+ on Windows
+    # Root cause is 'urllib3.util.ssl_.create_urllib3_context()'
     # See https://github.com/conda/conda-standalone/issues/86
     del os.environ["SSLKEYLOGFILE"]
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Looking into https://github.com/ContinuumIO/anaconda-issues/issues/13408

Closes #86 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
