### PR TITLE
Use .condarc file to configure conda-standalone

### DIFF
--- a/news/99-configure-conda-standalone
+++ b/news/99-configure-conda-standalone
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Configure conda-standalone binaries with .condarc files. (#97 via #99)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/99-configure-conda-standalone
+++ b/news/99-configure-conda-standalone
@@ -1,6 +1,7 @@
 ### Enhancements
 
 * Configure conda-standalone binaries with .condarc files. (#97 via #99)
+* Add environment variable `CONDA_RESTRICT_RC_SEARCH_PATH` and CLI option `--no-rc` to only load `.condarc` file delivered by `conda-standalone` bundle or `CONDARC` environment variable. (#99)
 
 ### Bug fixes
 

--- a/recipe/.condarc
+++ b/recipe/.condarc
@@ -1,0 +1,2 @@
+channels:
+  - conda-forge

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,7 +7,7 @@ COPY conda_src\conda\utils.py "%SP_DIR%\conda\utils.py" || goto :error
 RENAME "%SP_DIR%\conda\deprecations.py" deprecations.py.bak || goto :error
 COPY conda_src\conda\deprecations.py "%SP_DIR%\conda\deprecations.py" || goto :error
 RENAME "%SP_DIR%\conda\base\constants.py" constants.py.bak || goto :error
-COPY conda_src\conda\base\constants.py "%SP_DIR%\conda\base\constants.py.py" || goto :error
+COPY conda_src\conda\base\constants.py "%SP_DIR%\conda\base\constants.py" || goto :error
 
 :: we need these for noarch packages with entry points to work on windows
 COPY "conda_src\conda\shell\cli-%ARCH%.exe" entry_point_base.exe || goto :error

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,9 +1,13 @@
 @ECHO on
 
-FOR %%f IN (core\path_actions.py utils.py deprecations.py case\constants.py) DO (
-    RENAME "%SP_DIR%\conda\%%f" "%%f.bak" || goto :error
-    COPY "conda_src\conda\%%f" "%SP_DIR%\conda\%%f" || goto :error
-)
+RENAME "%SP_DIR%\conda\core\path_actions.py" path_actions.py.bak || goto :error
+COPY conda_src\conda\core\path_actions.py "%SP_DIR%\conda\core\path_actions.py" || goto :error
+RENAME "%SP_DIR%\conda\utils.py" utils.py.bak || goto :error
+COPY conda_src\conda\utils.py "%SP_DIR%\conda\utils.py" || goto :error
+RENAME "%SP_DIR%\conda\deprecations.py" deprecations.py.bak || goto :error
+COPY conda_src\conda\deprecations.py "%SP_DIR%\conda\deprecations.py" || goto :error
+RENAME "%SP_DIR%\conda\base\constants.py" constants.py.bak || goto :error
+COPY conda_src\conda\base\constants.py "%SP_DIR%\conda\base\constants.py.py" || goto :error
 
 :: we need these for noarch packages with entry points to work on windows
 COPY "conda_src\conda\shell\cli-%ARCH%.exe" entry_point_base.exe || goto :error

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,8 +1,8 @@
 @ECHO on
 
-FOR %%filename IN (core\path_actions.py utils.py deprecations.py case\constants.py) DO (
-    RENAME "%SP_DIR%\conda\%%filename" %%filename.bak || goto :error
-    COPY conda_src\conda\%%filename "%SP_DIR%\conda\%%filename" || goto :error
+FOR %%f IN (core\path_actions.py utils.py deprecations.py case\constants.py) DO (
+    RENAME "%SP_DIR%\conda\%%f" "%%f.bak" || goto :error
+    COPY "conda_src\conda\%%f" "%SP_DIR%\conda\%%f" || goto :error
 )
 
 :: we need these for noarch packages with entry points to work on windows

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,11 +1,9 @@
 @ECHO on
 
-RENAME "%SP_DIR%\conda\core\path_actions.py" path_actions.py.bak || goto :error
-COPY conda_src\conda\core\path_actions.py "%SP_DIR%\conda\core\path_actions.py" || goto :error
-RENAME "%SP_DIR%\conda\utils.py" utils.py.bak || goto :error
-COPY conda_src\conda\utils.py "%SP_DIR%\conda\utils.py" || goto :error
-RENAME "%SP_DIR%\conda\deprecations.py" deprecations.py.bak || goto :error
-COPY conda_src\conda\deprecations.py "%SP_DIR%\conda\deprecations.py" || goto :error
+FOR %%filename IN(core\path_actions.py utils.py deprecations.py case\constants.py) DO (
+    RENAME "%SP_DIR%\conda\%%filename" %%filename.bak || goto :error
+    COPY conda_src\conda\%%filename "%SP_DIR%\conda\%%filename" || goto :error
+)
 
 :: we need these for noarch packages with entry points to work on windows
 COPY "conda_src\conda\shell\cli-%ARCH%.exe" entry_point_base.exe || goto :error

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1,6 @@
 @ECHO on
 
-FOR %%filename IN(core\path_actions.py utils.py deprecations.py case\constants.py) DO (
+FOR %%filename IN (core\path_actions.py utils.py deprecations.py case\constants.py) DO (
     RENAME "%SP_DIR%\conda\%%filename" %%filename.bak || goto :error
     COPY conda_src\conda\%%filename "%SP_DIR%\conda\%%filename" || goto :error
 )

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,7 +2,7 @@ set -euxo pipefail
 
 # patched conda files
 # new files in patches need to be added here
-for fname in "core/path_actions.py" "utils.py" "deprecations.py"; do
+for fname in "core/path_actions.py" "utils.py" "deprecations.py" "base/constants.py"; do
   mv "$SP_DIR/conda/${fname}" "$SP_DIR/conda/${fname}.bak"
   cp "conda_src/conda/${fname}" "$SP_DIR/conda/${fname}"
 done

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ source:
     patches:
       - ../src/conda_patches/0001-Rename-and-replace-entrypoint-stub-exe.patch
       - ../src/conda_patches/0002-Manipulate-PATH-directly-instead-of-_call_ing-conda.patch
+      - ../src/conda_patches/0003-Restrict-search-paths.patch
 
   - url: https://github.com/conda/constructor/archive/{{ constructor_version }}.tar.gz  # [win]
     sha256: 0ea4f6d563a53ebb03475dc6d2d88d3ab01be4e9d291fd276c79315aa92e5114  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,8 @@ build:
   string: "g{{ GIT_FULL_HASH[:7] }}_py{{ pyver }}_{{ PKG_BUILDNUM }}"
   ignore_run_exports:
     - '*'
+  script_env:
+    - PYINSTALLER_CONDARC_DIR={{ RECIPE_DIR }}
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,6 +48,7 @@ test:
   requires:
     - pytest
     - menuinst >={{ menuinst_lower_bound }}
+    - ruamel.yaml
   source_files:
     - tests
   commands:

--- a/src/conda.exe.spec
+++ b/src/conda.exe.spec
@@ -64,7 +64,7 @@ elif sys.platform == "darwin":
 
 # Add .condarc file to bundle to configure channels
 # during the package building stage
-if "RECIPE_DIR" in os.environ:
+if "PYINSTALLER_CONDARC_DIR" in os.environ:
     condarc = os.path.join(os.environ["RECIPE_DIR"], ".condarc")
     if os.path.exists(condarc):
         datas.append((condarc, "."))

--- a/src/conda.exe.spec
+++ b/src/conda.exe.spec
@@ -62,6 +62,13 @@ elif sys.platform == "darwin":
     ]
     extra_exe_kwargs["entitlements_file"] = os.path.join(HERE, "entitlements.plist")
 
+# Add .condarc file to bundle to configure channels
+# during the package building stage
+if "RECIPE_DIR" in os.environ:
+    condarc = os.path.join(os.environ["RECIPE_DIR"], ".condarc")
+    if os.path.exists(condarc):
+        datas.append((condarc, "."))
+
 a = Analysis(['entry_point.py', 'imports.py'],
              pathex=['.'],
              binaries=binaries,

--- a/src/conda.exe.spec
+++ b/src/conda.exe.spec
@@ -65,7 +65,7 @@ elif sys.platform == "darwin":
 # Add .condarc file to bundle to configure channels
 # during the package building stage
 if "PYINSTALLER_CONDARC_DIR" in os.environ:
-    condarc = os.path.join(os.environ["RECIPE_DIR"], ".condarc")
+    condarc = os.path.join(os.environ["PYINSTALLER_CONDARC_DIR"], ".condarc")
     if os.path.exists(condarc):
         datas.append((condarc, "."))
 

--- a/src/conda_patches/0003-Restrict-search-paths.patch
+++ b/src/conda_patches/0003-Restrict-search-paths.patch
@@ -1,13 +1,21 @@
 diff --git a/conda/base/constants.py b/conda/base/constants.py
-index d38502a48..dc180c0bf 100644
+index d38502a48..b56724933 100644
 --- a/conda/base/constants.py
 +++ b/conda/base/constants.py
-@@ -25,42 +25,47 @@ machine_bits = 8 * struct.calcsize("P")
+@@ -10,6 +10,7 @@ Another important source of "static" configuration is conda/models/enums.py.
+ 
+ import struct
+ from enum import Enum, EnumMeta
++from os import environ
+ from os.path import join
+ 
+ from ..common.compat import on_win
+@@ -25,42 +26,47 @@ machine_bits = 8 * struct.calcsize("P")
  
  APP_NAME = "conda"
  
 -if on_win:  # pragma: no cover
-+if "CONDA_RESTRICT_RC_SEARCH_PATH" in os.environ:
++if "CONDA_RESTRICT_RC_SEARCH_PATH" in environ:
      SEARCH_PATH = (
 -        "C:/ProgramData/conda/.condarc",
 -        "C:/ProgramData/conda/condarc",

--- a/src/conda_patches/0003-Restrict-search-paths.patch
+++ b/src/conda_patches/0003-Restrict-search-paths.patch
@@ -1,0 +1,83 @@
+diff --git a/conda/base/constants.py b/conda/base/constants.py
+index d38502a48..dc180c0bf 100644
+--- a/conda/base/constants.py
++++ b/conda/base/constants.py
+@@ -25,42 +25,47 @@ machine_bits = 8 * struct.calcsize("P")
+ 
+ APP_NAME = "conda"
+ 
+-if on_win:  # pragma: no cover
++if "CONDA_RESTRICT_RC_SEARCH_PATH" in os.environ:
+     SEARCH_PATH = (
+-        "C:/ProgramData/conda/.condarc",
+-        "C:/ProgramData/conda/condarc",
+-        "C:/ProgramData/conda/condarc.d",
++        "$CONDARC",
+     )
+ else:
+-    SEARCH_PATH = (
+-        "/etc/conda/.condarc",
+-        "/etc/conda/condarc",
+-        "/etc/conda/condarc.d/",
+-        "/var/lib/conda/.condarc",
+-        "/var/lib/conda/condarc",
+-        "/var/lib/conda/condarc.d/",
++    if on_win:  # pragma: no cover
++        SEARCH_PATH = (
++            "C:/ProgramData/conda/.condarc",
++            "C:/ProgramData/conda/condarc",
++            "C:/ProgramData/conda/condarc.d",
++        )
++    else:
++        SEARCH_PATH = (
++            "/etc/conda/.condarc",
++            "/etc/conda/condarc",
++            "/etc/conda/condarc.d/",
++            "/var/lib/conda/.condarc",
++            "/var/lib/conda/condarc",
++            "/var/lib/conda/condarc.d/",
++        )
++
++    SEARCH_PATH += (
++        "$CONDA_ROOT/.condarc",
++        "$CONDA_ROOT/condarc",
++        "$CONDA_ROOT/condarc.d/",
++        "$XDG_CONFIG_HOME/conda/.condarc",
++        "$XDG_CONFIG_HOME/conda/condarc",
++        "$XDG_CONFIG_HOME/conda/condarc.d/",
++        "~/.config/conda/.condarc",
++        "~/.config/conda/condarc",
++        "~/.config/conda/condarc.d/",
++        "~/.conda/.condarc",
++        "~/.conda/condarc",
++        "~/.conda/condarc.d/",
++        "~/.condarc",
++        "$CONDA_PREFIX/.condarc",
++        "$CONDA_PREFIX/condarc",
++        "$CONDA_PREFIX/condarc.d/",
++        "$CONDARC",
+     )
+ 
+-SEARCH_PATH += (
+-    "$CONDA_ROOT/.condarc",
+-    "$CONDA_ROOT/condarc",
+-    "$CONDA_ROOT/condarc.d/",
+-    "$XDG_CONFIG_HOME/conda/.condarc",
+-    "$XDG_CONFIG_HOME/conda/condarc",
+-    "$XDG_CONFIG_HOME/conda/condarc.d/",
+-    "~/.config/conda/.condarc",
+-    "~/.config/conda/condarc",
+-    "~/.config/conda/condarc.d/",
+-    "~/.conda/.condarc",
+-    "~/.conda/condarc",
+-    "~/.conda/condarc.d/",
+-    "~/.condarc",
+-    "$CONDA_PREFIX/.condarc",
+-    "$CONDA_PREFIX/condarc",
+-    "$CONDA_PREFIX/condarc.d/",
+-    "$CONDARC",
+-)
+-
+ DEFAULT_CHANNEL_ALIAS = "https://conda.anaconda.org"
+ CONDA_HOMEPAGE_URL = "https://conda.io"
+ ERROR_UPLOAD_URL = "https://conda.io/conda-post/unexpected-error"

--- a/src/entry_point.py
+++ b/src/entry_point.py
@@ -298,6 +298,12 @@ def _conda_main():
     from conda.cli import main
 
     _fix_sys_path()
+    try:
+        no_rc = sys.argv.index("--no-rc")
+        os.environ["CONDA_RESTRICT_RC_SEARCH_PATH"] = "1"
+        del sys.argv[no_rc]
+    except ValueError:
+        pass
     return main()
 
 

--- a/src/entry_point.py
+++ b/src/entry_point.py
@@ -18,6 +18,14 @@ if os.name == "nt" and "SSLKEYLOGFILE" in os.environ:
     # See https://github.com/conda/conda-standalone/issues/86
     del os.environ["SSLKEYLOGFILE"]
 
+if (
+    not os.path.samefile(sys.prefix, os.environ.get("CONDA_ROOT"))
+    and "CONDARC" not in os.environ
+):
+    # Fallback option for when CONDA_ROOT is set externally, e.g.,
+    # during the test step of conda build
+    os.environ["CONDARC"] = os.path.join(sys.prefix, ".condarc")
+
 
 def _create_dummy_executor(*args, **kwargs):
     "use this for debugging, because ProcessPoolExecutor isn't pdb/ipdb friendly"

--- a/src/entry_point.py
+++ b/src/entry_point.py
@@ -18,12 +18,7 @@ if os.name == "nt" and "SSLKEYLOGFILE" in os.environ:
     # See https://github.com/conda/conda-standalone/issues/86
     del os.environ["SSLKEYLOGFILE"]
 
-if (
-    not os.path.samefile(sys.prefix, os.environ.get("CONDA_ROOT"))
-    and "CONDARC" not in os.environ
-):
-    # Fallback option for when CONDA_ROOT is set externally, e.g.,
-    # during the test step of conda build
+if "CONDARC" not in os.environ:
     os.environ["CONDARC"] = os.path.join(sys.prefix, ".condarc")
 
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 menuinst>=2
+ruamel.yaml

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -85,7 +85,7 @@ def test_conda_standalone_config(restrict_search_path, tmp_path, monkeypatch):
         expected_configs["recipe"] = recipe_config
 
     if restrict_search_path:
-        monkeypatch.setenv("CONDA_RESTRUCT_RC_SEARCH_PATH", "1")
+        monkeypatch.setenv("CONDA_RESTRICT_RC_SEARCH_PATH", "1")
     else:
         config_path = str(tmp_path / ".condarc")
         expected_configs[config_path] = {
@@ -96,6 +96,7 @@ def test_conda_standalone_config(restrict_search_path, tmp_path, monkeypatch):
         with open(config_path, "w") as crc:
             yaml.dump(expected_configs[config_path], crc)
         monkeypatch.setenv("CONDA_ROOT", str(tmp_path))
+    env = os.environ.copy()
 
     proc = run_conda(
         "config",
@@ -104,6 +105,7 @@ def test_conda_standalone_config(restrict_search_path, tmp_path, monkeypatch):
         check=True,
         capture_output=True,
         text=True,
+        env=env,
     )
     condarcs = json.loads(proc.stdout)
 
@@ -115,6 +117,7 @@ def test_conda_standalone_config(restrict_search_path, tmp_path, monkeypatch):
         check=True,
         capture_output=True,
         text=True,
+        env=env,
     )
     tmp_root = str(Path(proc.stdout).parent)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -123,17 +123,19 @@ def test_conda_standalone_config(restrict_search_path, tmp_path, monkeypatch):
 
     conda_configs = {}
     for filepath, config in condarcs.items():
-        if filepath.startswith(tmp_root):
-            conda_configs["recipe"] = config
-        elif Path(filepath).exists():
+        if Path(filepath).exists():
             conda_configs[filepath] = config
+        elif filepath.startswith(tmp_root):
+            conda_configs["recipe"] = config
     if restrict_search_path:
         assert expected_configs == conda_configs
     else:
         # If the search path is restricted, there may be other .condarc
         # files in the final config, so be less strict with assertions
         for filepath, config in expected_configs.items():
-            assert conda_configs.get(filepath) == config
+            assert (
+                conda_configs.get(filepath) == config
+            ), f"Incorrect config for {filepath}"
 
 
 def test_extract_conda_pkgs(tmp_path: Path):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -81,7 +81,12 @@ def test_conda_standalone_config():
         recipe_config = YAML().load(crc)
 
     proc = run_conda(
-        "config", "--show-sources", "--json", check=True, capture_output=True, text=True
+        "config",
+        "--show-sources",
+        "--json",
+        check=True,
+        capture_output=True,
+        text=True,
     )
     condarcs = json.loads(proc.stdout)
 
@@ -96,13 +101,13 @@ def test_conda_standalone_config():
     )
     tmp_root = Path(proc.stdout).parent
 
+    conda_config = None
     for filepath, config in condarcs.items():
         if filepath == "cmd_line":
             continue
         if Path(filepath).parent.parent == tmp_root:
             conda_config = config
             break
-
     assert recipe_config == conda_config
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -72,7 +72,7 @@ def test_constructor():
 @pytest.mark.parametrize("search_paths", ("all_rcs", "--no-rc", "env_var"))
 def test_conda_standalone_config(search_paths, tmp_path, monkeypatch):
     expected_configs = {}
-    if recipe_dir := os.environ.get("RECIPE_DIR"):
+    if recipe_dir := os.environ.get("PYINSTALLER_CONDARC_DIR"):
         recipe_condarc = Path(recipe_dir, ".condarc")
         if recipe_condarc.exists():
             yaml = YAML()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -124,7 +124,13 @@ def test_conda_standalone_config(restrict_search_path, tmp_path, monkeypatch):
             conda_configs["recipe"] = config
         elif Path(filepath).exists():
             conda_configs[filepath] = config
-    assert expected_configs == conda_configs
+    if restrict_search_path:
+        assert expected_configs == conda_configs
+    else:
+        # If the search path is restricted, there may be other .condarc
+        # files in the final config, so be less strict with assertions
+        for filepath, config in expected_configs.items():
+            assert conda_configs.get(filepath) == config
 
 
 def test_extract_conda_pkgs(tmp_path: Path):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -78,7 +78,7 @@ def test_conda_standalone_config(search_paths, tmp_path, monkeypatch):
             yaml = YAML()
             with open(condarc) as crc:
                 config = YAML().load(crc)
-                expected_configs["standalone"] = config
+                expected_configs["standalone"] = config.copy()
 
     config_args = ["--show-sources", "--json"]
     if search_paths == "env_var":
@@ -124,9 +124,9 @@ def test_conda_standalone_config(search_paths, tmp_path, monkeypatch):
     conda_configs = {}
     for filepath, config in condarcs.items():
         if Path(filepath).exists():
-            conda_configs[filepath] = config
+            conda_configs[filepath] = config.copy()
         elif rc_dir and filepath.startswith(tmp_root):
-            conda_configs["standalone"] = config
+            conda_configs["standalone"] = config.copy()
     if search_paths == "all_rcs":
         # If the search path is restricted, there may be other .condarc
         # files in the final config, so be less strict with assertions

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -73,7 +73,7 @@ def test_constructor():
     "RECIPE_DIR" not in os.environ,
     reason="Requires RECIPE_DIR environment variable.",
 )
-def test_conda_config():
+def test_conda_standalone_config():
     recipe_condarc = Path(os.environ["RECIPE_DIR"], ".condarc")
     if not recipe_condarc.exists():
         pytest.skip("Recipe does not have a .condarc file.")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -72,13 +72,13 @@ def test_constructor():
 @pytest.mark.parametrize("search_paths", ("all_rcs", "--no-rc", "env_var"))
 def test_conda_standalone_config(search_paths, tmp_path, monkeypatch):
     expected_configs = {}
-    if recipe_dir := os.environ.get("PYINSTALLER_CONDARC_DIR"):
-        recipe_condarc = Path(recipe_dir, ".condarc")
-        if recipe_condarc.exists():
+    if rc_dir := os.environ.get("PYINSTALLER_CONDARC_DIR"):
+        condarc = Path(rc_dir, ".condarc")
+        if condarc.exists():
             yaml = YAML()
-            with open(recipe_condarc) as crc:
-                recipe_config = YAML().load(crc)
-                expected_configs["recipe"] = recipe_config
+            with open(condarc) as crc:
+                config = YAML().load(crc)
+                expected_configs["standalone"] = config
 
     config_args = ["--show-sources", "--json"]
     if search_paths == "env_var":
@@ -108,7 +108,7 @@ def test_conda_standalone_config(search_paths, tmp_path, monkeypatch):
     condarcs = json.loads(proc.stdout)
 
     tmp_root = None
-    if recipe_dir:
+    if rc_dir:
         # Quick way to get the location conda-standalone is extracted into
         proc = run_conda(
             "python",
@@ -125,8 +125,8 @@ def test_conda_standalone_config(search_paths, tmp_path, monkeypatch):
     for filepath, config in condarcs.items():
         if Path(filepath).exists():
             conda_configs[filepath] = config
-        elif recipe_dir and filepath.startswith(tmp_root):
-            conda_configs["recipe"] = config
+        elif rc_dir and filepath.startswith(tmp_root):
+            conda_configs["standalone"] = config
     if search_paths == "all_rcs":
         # If the search path is restricted, there may be other .condarc
         # files in the final config, so be less strict with assertions


### PR DESCRIPTION
### Description

`conda` by default points to channels owned by Anaconda, which will soon be deprecated to make `conda` vendor agnostic (see https://github.com/conda/conda/issues/14217). `conda-standalone` contains the same fallback. This means that `conda-standalone` packages will point to Anaconda's channel even if they are built from another source (e.g., `conda-forge`). Additionally, once the fallback is removed, `conda-standalone` would not have a channel to point to by default.

~When `conda-standalone` extracts itself into a temporary directory, it treats that directory `CONDA_ROOT` and can look for `.condarc` files there. This PR uses that behavior to add a `.condarc` file, which can be used to point to a channel and define other types of behavior of the package.~

~There is one unique situation that causes this to fail: when `CONDA_ROOT` is set externally. This happens during the test phase of `conda build`. In that case, the `.condarc` file is not picked up anymore. I created a workaround by setting the `CONDARC` environment variable, but that changes the priority of the `.condarc` file. Under normal usage circumstances though, that workaround should not be needed though.~

Instead of the above, `CONDARC` is always set unless externally managed. To ensure that *only* the conda-standalone configuration is loaded, an environment variable has been added. It can additionally be set by running the `conda` subcommand with the `--no-rc` command, similar to what micromamba is doing.

Closes #97. While this doesn't make `conda-standalone` channel agnostic right away, it will follow `conda`'s deprecation cycle.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-standalone/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?