### PR TITLE
Pin action versions to commit SHA

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
       PYTHONUNBUFFERED: "1"
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca # v3.0.4
         with:
           auto-activate-base: true
           activate-environment: ""
@@ -55,7 +55,7 @@ jobs:
           CONDA_BLD_PATH: ${{ runner.temp }}/bld
         run: conda build recipe --override-channels -c conda-forge
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         if: github.event_name == 'pull_request'
         with:
           name: conda-standalone-${{ matrix.subdir }}


### PR DESCRIPTION
### Description

Some actions are not pinned to a commit SHA yet. This PR fixes that.

### Checklist - did you ...

~- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-standalone/blob/main/news/TEMPLATE)) for the next release's release notes?~
~- [ ] Add / update necessary tests?~
~- [ ] Add / update outdated documentation?~
