### PR TITLE
Prevent unbound error in test_conda_standalone_config

### DIFF
--- a/news/110-prevent-unbound-error-config-test
+++ b/news/110-prevent-unbound-error-config-test
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Prevent unbound error in test_conda_standalone_config. (#110)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -72,10 +72,10 @@ def test_constructor():
 @pytest.mark.parametrize("search_paths", ("all_rcs", "--no-rc", "env_var"))
 def test_conda_standalone_config(search_paths, tmp_path, monkeypatch):
     expected_configs = {}
+    yaml = YAML()
     if rc_dir := os.environ.get("PYINSTALLER_CONDARC_DIR"):
         condarc = Path(rc_dir, ".condarc")
         if condarc.exists():
-            yaml = YAML()
             with open(condarc) as crc:
                 config = YAML().load(crc)
                 expected_configs["standalone"] = config.copy()


### PR DESCRIPTION
### Description

The YAML loader does not have the proper scope and can be unbound in the `all_rcs` test if no `.condarc` file is added to the `conda-standalone` package. Moving it to the function scope fixes that problem.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-standalone/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?