### PR TITLE
 Bump to conda 24.11.0, libmambapy 1.5.11, constructor 3.10.0, menuinst 2.2.0

### DIFF
--- a/news/114-bump-24.11.0
+++ b/news/114-bump-24.11.0
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Bump to conda 24.11.0, libmambapy 1.5.11, constructor 3.10.0, menuinst 2.2.0. (#114)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set conda_libmamba_solver_version = "24.9.0" %}
 {% set libmambapy_version = "1.5.11" %}
 {% set constructor_version = "3.10.0" %}
-{% set menuinst_lower_bound = "2.1.2" %}
+{% set menuinst_lower_bound = "2.2.0" %}
 {% set python_version = "3.12.7" %}
 {% set pyver = "".join(python_version.split(".")[:2]) %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
-{% set conda_version = "24.9.2" %}
+{% set conda_version = "24.11.0" %}
 {% set conda_libmamba_solver_version = "24.9.0" %}
-{% set libmambapy_version = "1.5.10" %}
-{% set constructor_version = "3.9.3" %}
+{% set libmambapy_version = "1.5.11" %}
+{% set constructor_version = "3.10.0" %}
 {% set menuinst_lower_bound = "2.1.2" %}
 {% set python_version = "3.12.7" %}
 {% set pyver = "".join(python_version.split(".")[:2]) %}
@@ -14,7 +14,7 @@ source:
   - path: ../
 
   - url: https://github.com/conda/conda/archive/{{ conda_version }}.tar.gz
-    sha256: 7323ed0ae876f9d86f04c61ae01f53095adc570df27d9c375266df2745d51b8b
+    sha256: db49f3ead0efd8b2da95a5250860b653bc7216f2845367facdb5a4c51a541230
     folder: conda_src
     patches:
       - ../src/conda_patches/0001-Rename-and-replace-entrypoint-stub-exe.patch
@@ -22,7 +22,7 @@ source:
       - ../src/conda_patches/0003-Restrict-search-paths.patch
 
   - url: https://github.com/conda/constructor/archive/{{ constructor_version }}.tar.gz  # [win]
-    sha256: c88640ca1dcb93784cf754a16c53a098633808653aa52965c909a967b84815b9  # [win]
+    sha256: cfb77a5e64b5b2b44fdb5c3d04adbb652c1249a86ea2e88f9b293e367a809caf  # [win]
     folder: constructor_src  # [win]
 
 build:


### PR DESCRIPTION
### Description

Bump to conda 24.11.0, libmambapy 1.5.11, constructor 3.10.0, menuinst 2.2.0

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-standalone/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?
