### PR TITLE
Skip `test_uninstallation_remove_caches` if not on CI and when `CONDA_PKGS_DIRS` is set.

### DIFF
--- a/news/118-skip-uninstallation-caches-test
+++ b/news/118-skip-uninstallation-caches-test
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Skip `test_uninstallation_remove_caches` if not on CI or if `CONDA_PKGS_DIRS` is set. (#118)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -297,6 +297,7 @@ def test_uninstallation_menuinst(
     (True, False),
     ids=("shared pkgs", "remove pkgs"),
 )
+@pytest.mark.skipif(not ON_CI, reason="CI only - may remove shared caches")
 def test_uninstallation_remove_caches(
     mock_system_paths: dict[str, Path],
     tmp_env: TmpEnvFixture,

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -303,6 +303,8 @@ def test_uninstallation_remove_caches(
     tmp_env: TmpEnvFixture,
     shared_pkgs: bool,
 ):
+    if "CONDA_PKGS_DIRS" in os.environ:
+        pytest.skip("Test will fail with CONDA_PKGS_DIRS set.")
     # Set up notices
     if ON_WIN:
         try:


### PR DESCRIPTION
### Description

On a shared build system, `conda clean --all` may remove more cache files beyond the cache created by `pytest`, so it should be disabled if not on CI.

Additionall, the `CONDA_PKGS_DIRS` environment variable clobbers over the `.condarc` file, so the test will fail if the variable is set and should be skipped. Alternatively, that variable could also be monkeypatched out, but I'm not sure if this is 100% safe.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-standalone/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?