### PR TITLE
Run builds in a separate conda environment

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@d2e6a045a86077fb6cad6f5adf368e9076ddaa8d # v3.1.0
         with:
           auto-activate-base: true
-          activate-environment: ""
+          activate-environment: "test"
           run-post: false
 
       - name: Install dependencies

--- a/news/125-build-environment
+++ b/news/125-build-environment
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Run CI builds in a separate conda environment. (#125)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   - path: ../
 
   - url: https://github.com/conda/conda/archive/{{ conda_version }}.tar.gz
-    sha256: 781cfe0d1bcc8d6f0249ea58a7f9655a5089a8a6eeab1511ab556e6a8e742e23
+    sha256: 9ae1433949ca80eddfd81f0d5bd9eb8c291c7e101cbb440f8bdba324c9ea470c
     folder: conda_src
     patches:
       - ../src/conda_patches/0001-Rename-and-replace-entrypoint-stub-exe.patch


### PR DESCRIPTION
### Description

The `conda-anaconda-telemetry` plug-in appears to cause a problem on macOS when running `conda build` in the base environment (see https://github.com/anaconda/conda-anaconda-telemetry/issues/87).

Canary builds in other repositories and local builds suggest that building in a separate environment does not trigger the problem, so run builds in a separate environment to circumvent the problem.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-standalone/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?