### PR TITLE
Skip tests that require `sudo` if `sudo` is unavailable

### DIFF
--- a/news/126-skip-tests-sudo-unavailable
+++ b/news/126-skip-tests-sudo-unavailable
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Skip uninstallation tests that require `sudo` when `sudo` is unavailable. (#126)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

Some CIs do not run as root and do not allow `sudo` to be used, which causes test failures in some uninstallation tests. If a test requires `sudo`, test if `sudo` can be executed by the user and skip the test if not.

Note: the CI here will not show different behavior since the user on GitHub runners is root. I tested it on a virtual Debian though.

Closes #120.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-standalone/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?