### PR TITLE
Bump to conda 25.1.0, python 3.12.8, conda-libmamba-solver 25.1.0, constructor 3.11.1.

### DIFF
--- a/news/127-update-conda-25-1-0
+++ b/news/127-update-conda-25-1-0
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Bump to conda 25.1.0, python 3.12.8, conda-libmamba-solver 25.1.0, constructor 3.11.1. (#127)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/127-update-conda-25-1-0
+++ b/news/127-update-conda-25-1-0
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Bump to conda 25.1.0, python 3.12.8, libmambapy 2.0.5, conda-libmamba-solver 25.1.0, constructor 3.11.1. (#127)
+* Bump to conda 25.1.1, python 3.12.8, libmambapy 2.0.5, conda-libmamba-solver 25.1.1, constructor 3.11.1. (#127)
 
 ### Bug fixes
 

--- a/news/127-update-conda-25-1-0
+++ b/news/127-update-conda-25-1-0
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Bump to conda 25.1.0, python 3.12.8, conda-libmamba-solver 25.1.0, constructor 3.11.1. (#127)
+* Bump to conda 25.1.0, python 3.12.8, libmambapy 2.0.5, conda-libmamba-solver 25.1.0, constructor 3.11.1. (#127)
 
 ### Bug fixes
 

--- a/news/127-update-conda-25-1-0
+++ b/news/127-update-conda-25-1-0
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Bump to conda 25.1.1, python 3.12.8, libmambapy 2.0.5, conda-libmamba-solver 25.1.1, constructor 3.11.1. (#127)
+* Bump to conda 25.1.1, python 3.12.9, libmambapy 2.0.5, conda-libmamba-solver 25.3.0, constructor 3.11.3. (#127)
 
 ### Bug fixes
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,9 @@
 {% set conda_version = "25.1.1" %}
-{% set conda_libmamba_solver_version = "25.1.1" %}
+{% set conda_libmamba_solver_version = "25.3.0" %}
 {% set libmambapy_version = "2.0.5" %}
-{% set constructor_version = "3.11.1" %}
+{% set constructor_version = "3.11.3" %}
 {% set menuinst_lower_bound = "2.2.0" %}
-{% set python_version = "3.12.8" %}
+{% set python_version = "3.12.9" %}
 {% set pyver = "".join(python_version.split(".")[:2]) %}
 
 package:
@@ -22,7 +22,7 @@ source:
       - ../src/conda_patches/0003-Restrict-search-paths.patch
 
   - url: https://github.com/conda/constructor/archive/{{ constructor_version }}.tar.gz  # [win]
-    sha256: bf35e45f7bd308079f4495e6d0905242fea1fb24fbffcfc07752b30d7a2ba3eb  # [win]
+    sha256: b1b0bb88a8934508f837c892b4f9c3f08b34bf044b704b1fde44b148c236efbe  # [win]
     folder: constructor_src  # [win]
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set conda_version = "25.1.0" %}
-{% set conda_libmamba_solver_version = "25.1.0" %}
+{% set conda_version = "25.1.1" %}
+{% set conda_libmamba_solver_version = "25.1.1" %}
 {% set libmambapy_version = "2.0.5" %}
 {% set constructor_version = "3.11.1" %}
 {% set menuinst_lower_bound = "2.2.0" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set conda_version = "25.1.0" %}
 {% set conda_libmamba_solver_version = "25.1.0" %}
-{% set libmambapy_version = "1.5.11" %}
+{% set libmambapy_version = "2.0.5" %}
 {% set constructor_version = "3.11.1" %}
 {% set menuinst_lower_bound = "2.2.0" %}
 {% set python_version = "3.12.8" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   - path: ../
 
   - url: https://github.com/conda/conda/archive/{{ conda_version }}.tar.gz
-    sha256: a9844400973a8c871391dbec48ee45d1715dd846160e724c2b64f7e02394fc18
+    sha256: 97dcb3857f5d65feb2b877a64bcb73a4fc4dbeee93085b848dfffa5985533714
     folder: conda_src
     patches:
       - ../src/conda_patches/0001-Rename-and-replace-entrypoint-stub-exe.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,9 @@
-{% set conda_version = "24.11.0" %}
-{% set conda_libmamba_solver_version = "24.9.0" %}
+{% set conda_version = "25.1.0" %}
+{% set conda_libmamba_solver_version = "25.1.0" %}
 {% set libmambapy_version = "1.5.11" %}
-{% set constructor_version = "3.10.0" %}
+{% set constructor_version = "3.11.1" %}
 {% set menuinst_lower_bound = "2.2.0" %}
-{% set python_version = "3.12.7" %}
+{% set python_version = "3.12.8" %}
 {% set pyver = "".join(python_version.split(".")[:2]) %}
 
 package:
@@ -14,7 +14,7 @@ source:
   - path: ../
 
   - url: https://github.com/conda/conda/archive/{{ conda_version }}.tar.gz
-    sha256: 9ae1433949ca80eddfd81f0d5bd9eb8c291c7e101cbb440f8bdba324c9ea470c
+    sha256: a9844400973a8c871391dbec48ee45d1715dd846160e724c2b64f7e02394fc18
     folder: conda_src
     patches:
       - ../src/conda_patches/0001-Rename-and-replace-entrypoint-stub-exe.patch
@@ -22,7 +22,7 @@ source:
       - ../src/conda_patches/0003-Restrict-search-paths.patch
 
   - url: https://github.com/conda/constructor/archive/{{ constructor_version }}.tar.gz  # [win]
-    sha256: cfb77a5e64b5b2b44fdb5c3d04adbb652c1249a86ea2e88f9b293e367a809caf  # [win]
+    sha256: bf35e45f7bd308079f4495e6d0905242fea1fb24fbffcfc07752b30d7a2ba3eb  # [win]
     folder: constructor_src  # [win]
 
 build:


### PR DESCRIPTION
### Description

Bump to conda 25.1.0, python 3.12.8, libmambapy 2.0.5, conda-libmamba-solver 25.1.0, constructor 3.11.1.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-standalone/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?