### PR TITLE
Use filter in tarfile.extractall when available

### DIFF
--- a/news/144-use-filter-in-tarfile.extractall-when-available
+++ b/news/144-use-filter-in-tarfile.extractall-when-available
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Include a filter arguments to extractall when possible to avoid a DeprecationWarnings. (#144)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/144-use-filter-in-tarfile.extractall-when-available
+++ b/news/144-use-filter-in-tarfile.extractall-when-available
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Include a filter arguments to extractall when possible to avoid a DeprecationWarnings. (#144)
+* Include a filter arguments to `extractall` when possible to avoid a DeprecationWarnings. (#143 via #144)
 
 ### Deprecations
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ requirements:
     - python ={{ python_version }}
     - conda ={{ conda_version }}
     - conda-package-handling >=2.3.0
-    - conda-package-streaming >=0.9.0
+    - conda-package-streaming >=0.12.0
     - menuinst >={{ menuinst_lower_bound }}
     - conda-libmamba-solver ={{ conda_libmamba_solver_version }}
     - libmambapy ={{ libmambapy_version }}

--- a/src/entry_point.py
+++ b/src/entry_point.py
@@ -253,7 +253,10 @@ def _constructor_extract_tarball():
     from conda_package_streaming.package_streaming import TarfileNoSameOwner
 
     t = TarfileNoSameOwner.open(mode="r|*", fileobj=sys.stdin.buffer)
-    t.extractall()
+    tar_args = {}
+    if hasattr(t, "extraction_filter"):
+        tar_args["filter"] = "fully_trusted"
+    t.extractall(**tar_args)
     t.close()
 
 

--- a/src/entry_point.py
+++ b/src/entry_point.py
@@ -255,7 +255,7 @@ def _constructor_extract_tarball():
     t = TarfileNoSameOwner.open(mode="r|*", fileobj=sys.stdin.buffer)
     tar_args = {}
     if hasattr(t, "extraction_filter"):
-        tar_args["filter"] = "fully_trusted"
+        tar_args["filter"] = "data"
     t.extractall(**tar_args)
     t.close()
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -145,9 +145,9 @@ def test_extract_tarball_no_raise_deprecation_warning(tmp_path: Path):
         capture_output=True,
         check=True,
     )
-    assert b"DeprecationWarning" not in process.stderr
+    assert b"DeprecationWarning: Python" not in process.stderr
     # warnings should be send to stderr but check stdout for completeness
-    assert b"DeprecationWarning" not in process.stdout
+    assert b"DeprecationWarning: Python" not in process.stdout
 
 
 def test_extract_tarball_umask(tmp_path: Path):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -123,6 +123,23 @@ def test_extract_conda_pkgs(tmp_path: Path):
     run_conda("constructor", "--prefix", tmp_path, "--extract-conda-pkgs", check=True)
 
 
+def test_extract_tarball_no_raise_deprecation_warning(tmp_path: Path):
+    # See https://github.com/conda/conda-standalone/issues/143
+    tarbytes = (HERE / "data" / "futures-compat-1.0-py3_0.tar.bz2").read_bytes()
+    process = run_conda(
+        "constructor",
+        "--prefix",
+        tmp_path,
+        "--extract-tarball",
+        input=tarbytes,
+        capture_output=True,
+        check=True,
+    )
+    assert b"DeprecationWarning" not in process.stderr
+    # warnings should be send to stderr but check stdout for completeness
+    assert b"DeprecationWarning" not in process.stdout
+
+
 def test_extract_tarball_umask(tmp_path: Path):
     "Ported from https://github.com/conda/conda-package-streaming/pull/65"
 


### PR DESCRIPTION
### Description

Include a `filter` argument to `extractall` when supported by Python. This argument was added to patch versions of Pythoon 3.8 and above.

closes #143 

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-standalone/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?
