### PR TITLE
Refactor CLI options into subcommands

### DIFF
--- a/news/177-create-subcommands
+++ b/news/177-create-subcommands
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Refactor CLI commands `--rm-menus`, `--make-menus`, `--extract-conda-pkgs`, and `--extract-tarball` into a `conda menuinst` and `conda constructor extract` subcommand. (#176 via #177)

--- a/src/entry_point.py
+++ b/src/entry_point.py
@@ -43,12 +43,13 @@ def _constructor_parse_cli():
         _NumProcessorsAction,
     )
 
-    # Remove "constructor" so that it does not clash with the subcommands
-    del sys.argv[1]
-    p = argparse.ArgumentParser(
-        prog="conda.exe constructor", description="constructor helper subcommand"
+    p = argparse.ArgumentParser(prog="conda.exe")
+    constructor_subcommand = p.add_subparsers(dest="_")
+    constructor_subparser = constructor_subcommand.add_parser(
+        name="constructor",
+        help="constructor helper subcommand",
     )
-    subcommands = p.add_subparsers(dest="command")
+    subcommands = constructor_subparser.add_subparsers(dest="command")
 
     extract_subcommand = subcommands.add_parser(
         "extract",
@@ -77,7 +78,7 @@ def _constructor_parse_cli():
         default=DEFAULT_NUM_PROCESSORS,
         metavar="N",
         action=_NumProcessorsAction,
-        help="Number of processors to use with --extract-conda-pkgs. "
+        help="Number of processors to use with --conda. "
         "Value must be int between 0 (auto) and the number of processors. "
         f"Defaults to {DEFAULT_NUM_PROCESSORS}.",
     )

--- a/tests/test_menuinst.py
+++ b/tests/test_menuinst.py
@@ -2,10 +2,23 @@ import os
 import sys
 from pathlib import Path
 
+import pytest
 from utils import run_conda
 
 
-def test_menuinst_constructor(tmp_path: Path, clean_shortcuts: dict[str, list[Path]]):
+@pytest.mark.parametrize(
+    "args_install,args_remove",
+    (
+        pytest.param(("menuinst", "--install"), ("menuinst", "--remove"), id="menuinst"),
+        pytest.param(("constructor", "--make-menus"), ("constructor", "--rm-menus"), id="legacy"),
+    ),
+)
+def test_menuinst_conda_standalone(
+    tmp_path: Path,
+    args_install: tuple[str, ...],
+    args_remove: tuple[str, ...],
+    clean_shortcuts: dict[str, list[Path]],
+):
     "The constructor helper should also be able to process menuinst JSONs"
     run_kwargs = dict(capture_output=True, text=True, check=True)
     process = run_conda(
@@ -26,14 +39,13 @@ def test_menuinst_constructor(tmp_path: Path, clean_shortcuts: dict[str, list[Pa
     env = os.environ.copy()
     env["CONDA_ROOT_PREFIX"] = sys.prefix
     process = run_conda(
-        "constructor",
+        *args_install,
         # Not supported in micromamba's interface yet
         # use CONDA_ROOT_PREFIX instead
         # "--root-prefix",
         # sys.prefix,
         "--prefix",
         tmp_path,
-        "--make-menus",
         **run_kwargs,
         env=env,
     )
@@ -47,14 +59,13 @@ def test_menuinst_constructor(tmp_path: Path, clean_shortcuts: dict[str, list[Pa
     assert sorted(shortcuts_found) == sorted(clean_shortcuts.keys())
 
     process = run_conda(
-        "constructor",
+        *args_remove,
         # Not supported in micromamba's interface yet
         # use CONDA_ROOT_PREFIX instead
         # "--root-prefix",
         # sys.prefix,
         "--prefix",
         tmp_path,
-        "--rm-menus",
         **run_kwargs,
         env=env,
     )


### PR DESCRIPTION
### Description

Refactor CLI commands `--rm-menus`, `--make-menus`, `--extract-conda-pkgs`, and `--extract-tarball` into a `conda menuinst` and `conda constructor extract` subcommand. This is needed for the upcoming `menuinst` and `constructor` plug-ins, which will result in subcommands instead of flat CLI arguments. It also provides a cleaner CLI. Eventually, these subcommands will be removed.

Backwards compatibility is achieved by patching `sys.argv` and tests are added for both sets of CLI arguments. To fully ensure that the tests pass, #175 should probably merged first.

Closes #176 

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-standalone/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?