### PR TITLE
Add `conda` environment information to test builds for debugging

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,13 @@ jobs:
         shell: bash -el {0}
         run: conda install -y "conda-build!=3.28.0,!=3.28.1" anaconda-client
 
+      - name: Debugging information
+        run: |
+          conda info
+          conda config --show-sources
+          conda list
+        shell: bash -el {0}
+
       - name: Build recipe
         shell: bash -el {0}
         env:

--- a/news/192-add-debug-information
+++ b/news/192-add-debug-information
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Output `conda` environment information during test builds to help debugging. (#192)


### PR DESCRIPTION
### Description

Output `conda` environment information to help debugging. In several repositories of the `conda` organization, the canary uploads are currently failing. `conda-standalone` does not use the `canary-release` action but instead uses `anaconda-client` directly.

While this succeeds, outputting environment information to help debugging efforts in the future would still be helpful.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-standalone/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?