### PR TITLE
Restore old patch version to avoid calling activate.bat

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
         shell: bash -el {0}
         env:
           CONDA_BLD_PATH: ${{ runner.temp }}/bld
-        run: conda build recipe --override-channels -c conda-forge
+        run: conda-build recipe --override-channels -c conda-forge
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: github.event_name == 'pull_request'

--- a/news/268-restore-path-manipulation-patch
+++ b/news/268-restore-path-manipulation-patch
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Restore old `PATH` manipulation patch version to avoid calling `activate.bat` during post-link step. (#268)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,6 +61,7 @@ requirements:
 test:
   requires:
     - conda
+    - conda-build
     - menuinst >={{ menuinst_lower_bound }}
     - pytest
     - ruamel.yaml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ source:
     # from src to PREFIX in build.sh and bld.bat
     patches:
       - ../src/conda_patches/0001-Rename-and-replace-entrypoint-stub-exe.patch
+      - ../src/conda_patches/0002-Manipulate-PATH-directly-instead-of-_call_ing-conda.patch
       - ../src/conda_patches/0003-Restrict-search-paths.patch
       - ../src/conda_patches/0004-Fix-conda-run.patch
 

--- a/src/conda_patches/0002-Manipulate-PATH-directly-instead-of-_call_ing-conda.patch
+++ b/src/conda_patches/0002-Manipulate-PATH-directly-instead-of-_call_ing-conda.patch
@@ -1,35 +1,22 @@
-From 39070423f8c5318bc6d8a7c69dec2423647331be Mon Sep 17 00:00:00 2001
+From a1b3edbdcccaec30ab92a4f0beb52e49606cf358 Mon Sep 17 00:00:00 2001
 From: Nehal J Wani <nehaljw.kkd1@gmail.com>
 Date: Tue, 13 Aug 2019 07:46:10 -0400
-Subject: [PATCH 2/4] Manipulate PATH directly instead of _call_ing conda.bat
+Subject: [PATCH 2/3] Manipulate PATH directly instead of _call_ing conda.bat
 
 ---
- conda/utils.py | 24 +++++++++---------------
- 1 file changed, 9 insertions(+), 15 deletions(-)
+ conda/utils.py | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
 
 diff --git a/conda/utils.py b/conda/utils.py
-index 8667a07aa..38648f99a 100644
+index b9a3cc5cc..5f3e29c5c 100644
 --- a/conda/utils.py
 +++ b/conda/utils.py
-@@ -251,21 +251,15 @@ def wrap_subprocess_call(
+@@ -438,7 +438,16 @@ def wrap_subprocess_call(
+             # after all!
              # fh.write("@FOR /F \"tokens=100\" %%F IN ('chcp') DO @SET CONDA_OLD_CHCP=%%F\n")
              # fh.write('@chcp 65001>NUL\n')
- 
--            # We pursue activation inline here, which allows us to avoid
--            # spawning a `conda activate` process at wrapper runtime.
--            activator_cls = _build_activator_cls("cmd.exe.run")
--            activator_args = ["activate"]
--            if dev_mode:
--                activator_args.append("--dev")
--            activator_args.append(prefix)
--
--            activator = activator_cls(activator_args)
--            activator._parse_and_set_args()
--            activate_script = activator.activate()
--
--            for line in activate_script.splitlines():
--                fh.write(f"{silencer}{line}\n")
--
+-            fh.write(f'{silencer}CALL "{conda_bat}" activate "{prefix}"\n')
++            # fh.write(f'{silencer}CALL "{conda_bat}" activate "{prefix}"\n')
 +            fh.write(
 +                f'SET "PATH={prefix};'
 +                f'{prefix}\\Library\\mingw-w64\\bin;'
@@ -42,6 +29,6 @@ index 8667a07aa..38648f99a 100644
              fh.write(f"{silencer}IF %ERRORLEVEL% NEQ 0 EXIT /b %ERRORLEVEL%\n")
              if debug_wrapper_scripts:
                  fh.write("echo *** environment after *** 1>&2\n")
--- 
-2.51.1.windows.1
+--
+2.32.1 (Apple Git-133)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,14 @@
 import itertools
 import os
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 
 import pytest
 from utils import _get_shortcut_dirs
+
+TEST_PACKAGE_DIR = Path(__file__).parent / "test_package"
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -61,3 +64,22 @@ def clean_shortcuts(tmp_path: Path, menuinst_pkg_specs: list[tuple[str, dict[str
     _clean_macos_apps(shortcuts)
     yield shortcuts
     _clean_macos_apps(shortcuts)
+
+
+@pytest.fixture
+def test_package(tmp_path: Path) -> Path:
+    # This should technically be a session-scoped fixture,
+    # but then we can't use tmp_path. Since the package is
+    # tiny and only used in one test, we can get away with it
+    subprocess.run(
+        [
+            "conda-build",
+            TEST_PACKAGE_DIR,
+            "--output-folder",
+            tmp_path,
+            "--croot",
+            tmp_path,
+        ]
+    )
+    package_file = Path(next((tmp_path / "noarch").glob("test_package-*.conda")))
+    return package_file

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,5 @@
 conda
+conda-build
 menuinst>=2
 pytest
 ruamel.yaml

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,9 +15,9 @@ HERE = Path(__file__).parent
 @pytest.mark.parametrize("solver", ["classic", "libmamba"])
 def test_new_environment(tmp_path, solver):
     env = os.environ.copy()
-    env_location = tmp_path / "env"
+    env_location = tmp_path / "env" / "envs" / "spyder"
     env["CONDA_SOLVER"] = solver
-    env["CONDA_ROOT_PREFIX"] = str(env_location)
+    env["CONDA_ROOT_PREFIX"] = str(env_location.parent.parent)
     run_conda(
         "create",
         "-p",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -29,7 +29,7 @@ def test_new_environment(tmp_path, solver):
         env=env,
         check=True,
     )
-    assert next((env_location / "conda-meta").glob("spyder-*.json"), None)
+    assert next((env_location / "conda-meta").glob("gdk-pixbuf-*.json"), None)
     run_conda(
         "remove",
         "-p",
@@ -38,7 +38,7 @@ def test_new_environment(tmp_path, solver):
         env=env,
         check=True,
     )
-    assert not next((env_location / "conda-meta").glob("spyder-*.json"), None)
+    assert not next((env_location / "conda-meta").glob("gdk-pixbuf-*.json"), None)
 
 
 def test_install_conda(tmp_path):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,6 +14,7 @@ HERE = Path(__file__).parent
 
 @pytest.mark.parametrize("solver", ["classic", "libmamba"])
 def test_new_environment(tmp_path, solver):
+    # Use a package that contains post-link scripts
     env = os.environ.copy()
     env_location = tmp_path / "env"
     env["CONDA_SOLVER"] = solver
@@ -24,7 +25,7 @@ def test_new_environment(tmp_path, solver):
         "-y",
         "-c",
         "conda-forge",
-        "spyder",
+        "gdk-pixbuf",
         env=env,
         check=True,
     )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,31 +14,20 @@ HERE = Path(__file__).parent
 
 @pytest.mark.parametrize("solver", ["classic", "libmamba"])
 def test_new_environment(tmp_path, solver):
-    # Use a package that contains post-link scripts
     env = os.environ.copy()
-    env_location = tmp_path / "env"
     env["CONDA_SOLVER"] = solver
     run_conda(
         "create",
         "-p",
-        env_location,
+        tmp_path / "env",
         "-y",
         "-c",
         "conda-forge",
-        "gdk-pixbuf",
+        "libzlib",
         env=env,
         check=True,
     )
-    assert next((env_location / "conda-meta").glob("gdk-pixbuf-*.json"), None)
-    run_conda(
-        "remove",
-        "-p",
-        tmp_path / "env",
-        "--all",
-        env=env,
-        check=True,
-    )
-    assert not next((env_location / "conda-meta").glob("gdk-pixbuf-*.json"), None)
+    assert list((tmp_path / "env" / "conda-meta").glob("libzlib-*.json"))
 
 
 def test_install_conda(tmp_path):
@@ -57,6 +46,32 @@ def test_install_conda(tmp_path):
         conda_json_regex.search(str(file))
         for file in (tmp_path / "env" / "conda-meta").glob("conda-*.json")
     )
+
+
+def test_install_link_scripts(tmp_path: Path, test_package: Path):
+    env_location = tmp_path / "env"
+    run_conda(
+        "create",
+        "-p",
+        env_location,
+        test_package,
+        "-y",
+        check=True,
+    )
+    assert next((env_location / "conda-meta").glob("test_package-*.json"), None)
+    script_output = env_location / "script_output.txt"
+    assert script_output.exists()
+    assert script_output.read_text().splitlines() == ["pre-link", "post-link"]
+    run_conda(
+        "remove",
+        "-p",
+        env_location,
+        "--all",
+        "-y",
+        check=True,
+    )
+    assert next((env_location / "conda-meta").glob("test_package-*.json"), None) is None
+    assert not (env_location / "uninstall_output.txt").exists()
 
 
 def test_constructor():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,9 +15,8 @@ HERE = Path(__file__).parent
 @pytest.mark.parametrize("solver", ["classic", "libmamba"])
 def test_new_environment(tmp_path, solver):
     env = os.environ.copy()
-    env_location = tmp_path / "env" / "envs" / "spyder"
+    env_location = tmp_path / "env"
     env["CONDA_SOLVER"] = solver
-    env["CONDA_ROOT_PREFIX"] = str(env_location.parent.parent)
     run_conda(
         "create",
         "-p",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,19 +15,30 @@ HERE = Path(__file__).parent
 @pytest.mark.parametrize("solver", ["classic", "libmamba"])
 def test_new_environment(tmp_path, solver):
     env = os.environ.copy()
+    env_location = tmp_path / "env"
     env["CONDA_SOLVER"] = solver
+    env["CONDA_ROOT_PREFIX"] = str(env_location)
     run_conda(
         "create",
         "-p",
-        tmp_path / "env",
+        env_location,
         "-y",
         "-c",
         "conda-forge",
-        "libzlib",
+        "spyder",
         env=env,
         check=True,
     )
-    assert list((tmp_path / "env" / "conda-meta").glob("libzlib-*.json"))
+    assert next((env_location / "conda-meta").glob("spyder-*.json"), None)
+    run_conda(
+        "remove",
+        "-p",
+        tmp_path / "env",
+        "--all",
+        env=env,
+        check=True,
+    )
+    assert not next((env_location / "conda-meta").glob("spyder-*.json"), None)
 
 
 def test_install_conda(tmp_path):

--- a/tests/test_package/meta.yaml
+++ b/tests/test_package/meta.yaml
@@ -1,0 +1,10 @@
+package:
+  name: test_package
+  version: 1.0.0
+
+build:
+  number: 0
+  noarch: generic
+
+about:
+  summary: Test package with pre-link, post-link, and pre-unlink steps

--- a/tests/test_package/post-link.bat
+++ b/tests/test_package/post-link.bat
@@ -1,4 +1,4 @@
 @ECHO OFF
 
-ECHO post-link >> %PREFIX%\script_output.txt
+ECHO post-link>> %PREFIX%\script_output.txt
 EXIT /B %ERRORLEVEL%

--- a/tests/test_package/post-link.bat
+++ b/tests/test_package/post-link.bat
@@ -1,4 +1,4 @@
 @ECHO OFF
 
-echo "post-link" >> %PREFIX%\script_output.txt
+ECHO post-link >> %PREFIX%\script_output.txt
 EXIT /B %ERRORLEVEL%

--- a/tests/test_package/post-link.bat
+++ b/tests/test_package/post-link.bat
@@ -1,0 +1,4 @@
+@ECHO OFF
+
+echo "post-link" >> %PREFIX%\script_output.txt
+EXIT /B %ERRORLEVEL%

--- a/tests/test_package/post-link.sh
+++ b/tests/test_package/post-link.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+echo "post-link" >> "${PREFIX}/script_output.txt"

--- a/tests/test_package/pre-link.bat
+++ b/tests/test_package/pre-link.bat
@@ -1,4 +1,4 @@
 @ECHO OFF
 
-echo "pre-link" >> %PREFIX%\script_output.txt
+ECHO pre-link >> %PREFIX%\script_output.txt
 EXIT /B %ERRORLEVEL%

--- a/tests/test_package/pre-link.bat
+++ b/tests/test_package/pre-link.bat
@@ -1,4 +1,4 @@
 @ECHO OFF
 
-ECHO pre-link >> %PREFIX%\script_output.txt
+ECHO pre-link>> %PREFIX%\script_output.txt
 EXIT /B %ERRORLEVEL%

--- a/tests/test_package/pre-link.bat
+++ b/tests/test_package/pre-link.bat
@@ -1,0 +1,4 @@
+@ECHO OFF
+
+echo "pre-link" >> %PREFIX%\script_output.txt
+EXIT /B %ERRORLEVEL%

--- a/tests/test_package/pre-link.sh
+++ b/tests/test_package/pre-link.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+echo "pre-link" >> "${PREFIX}/script_output.txt"

--- a/tests/test_package/pre-unlink.bat
+++ b/tests/test_package/pre-unlink.bat
@@ -1,4 +1,4 @@
 @ECHO OFF
 
-ECHO "pre-unlink" > %PREFIX%\uninstall_output.txt
+ECHO pre-unlink > %PREFIX%\uninstall_output.txt
 EXIT /B %ERRORLEVEL%

--- a/tests/test_package/pre-unlink.bat
+++ b/tests/test_package/pre-unlink.bat
@@ -1,4 +1,4 @@
 @ECHO OFF
 
-ECHO pre-unlink > %PREFIX%\uninstall_output.txt
+ECHO pre-unlink> %PREFIX%\uninstall_output.txt
 EXIT /B %ERRORLEVEL%

--- a/tests/test_package/pre-unlink.bat
+++ b/tests/test_package/pre-unlink.bat
@@ -1,0 +1,4 @@
+@ECHO OFF
+
+ECHO "pre-unlink" > %PREFIX%\uninstall_output.txt
+EXIT /B %ERRORLEVEL%

--- a/tests/test_package/pre-unlink.sh
+++ b/tests/test_package/pre-unlink.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+echo "pre-unlink" > "${PREFIX}/uninstall_output.txt"


### PR DESCRIPTION
### Description

`conda` has recently reverted a commits to remove the inline activation for `conda run`. This re-added calling `activate.bat`: https://github.com/conda/conda/pull/15896/changes#diff-45099e3c97476be6dface3845f19234f5ee11b8c71803a29f629c0b87eca70b3

#241 removed the [patch to manipulate `PATH`](https://github.com/conda/conda-standalone/blob/e99c2191e056511f01f666c22fe6f8e6eb283155/src/conda_patches/0002-Manipulate-PATH-directly-instead-of-_call_ing-conda.patch). With the upstream revert, this patch becomes necessary again, or installations with post-link scripts fail.

I verified this on my local machine for Windows. To test this, we would need a package that uses post-link scripts. `spyder` has those for all platforms, but is heavier to use than the previous package (compare [this PR](https://github.com/conda/conda-standalone/actions/runs/25191318579/job/73861726845) with a [recent run](https://github.com/conda/conda-standalone/actions/runs/25152692704)).

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-standalone/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?