### PR TITLE
Add self-updater for single-binary builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ MANIFEST
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+src/_version.py
 
 # Installer logs
 pip-log.txt

--- a/news/279-self-update-single
+++ b/news/279-self-update-single
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add self-updater for single-binary builds. (#279)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/279-self-update-single
+++ b/news/279-self-update-single
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Add self-updater for single-binary builds. (#279)
+* Add self-updater command (`conda constructor update-boostrapper`) for single-binary builds. (#279)
 
 ### Bug fixes
 

--- a/src/conda.exe.spec
+++ b/src/conda.exe.spec
@@ -5,6 +5,7 @@ import site
 import sys
 
 import conda.plugins.manager
+from conda import __version__ as conda_version
 from menuinst.platforms.base import SCHEMA_VERSION
 from PyInstaller.utils.hooks import collect_data_files, collect_submodules, copy_metadata
 
@@ -135,6 +136,13 @@ for name, module in conda_plugin_manager.list_name_plugin():
         datas.extend(collect_data_files(package_name))
     # metadata is needed for conda to find the plug-in
     datas.extend(copy_metadata(package_name))
+
+# Write version file to capture the package version since
+# conda-standalone may have postN releases.
+version = os.environ.get("PKG_VERSION", conda_version)
+with open(os.path.join(HERE, "_version.py"), "w") as f:
+    f.write(f'__version__ = "{version}"\n')
+datas.append((os.path.join(HERE, "_version.py"), "conda_constructor"))
 
 a = Analysis(['entry_point.py'],
              pathex=['.'],

--- a/src/conda.exe.spec
+++ b/src/conda.exe.spec
@@ -140,8 +140,10 @@ for name, module in conda_plugin_manager.list_name_plugin():
 # Write version file to capture the package version since
 # conda-standalone may have postN releases.
 version = os.environ.get("PKG_VERSION", conda_version)
+build_number = int(os.environ.get("PKG_BUILDNUM", 0))
 with open(os.path.join(HERE, "_version.py"), "w") as f:
     f.write(f'__version__ = "{version}"\n')
+    f.write(f"__buildnum__ = {build_number}\n")
 datas.append((os.path.join(HERE, "_version.py"), "conda_constructor"))
 
 a = Analysis(['entry_point.py'],

--- a/src/conda_constructor/cli.py
+++ b/src/conda_constructor/cli.py
@@ -148,6 +148,17 @@ def configure_parser(parser: ArgumentParser) -> None:
     _add_prefix(uninstall_parser)
     _add_uninstall(uninstall_parser)
 
+    # Not implemented for onedir builds
+    if Path(sys.prefix).name != "_internal":
+        update_subparser = subparsers.add_parser(
+            "update-bootstrapper", description="Updates the conda-standalone binary."
+        )
+        update_subparser.add_argument(
+            "--force",
+            action="store_true",
+            help="Update even if already at the latest version.",
+        )
+
     if sys.platform != "win32":
         return
     windows_parser = subparsers.add_parser(
@@ -189,6 +200,10 @@ def execute(args: Namespace) -> None | int:
                 "remove_user_data": args.remove_user_data,
             }
         )
+    elif args.cmd == "update-bootstrapper":
+        from .update_bootstrapper import update_bootstrapper
+
+        action = update_bootstrapper
     elif args.cmd == "windows" and sys.platform == "win32":
         if args.windows_cmd == "path":
             from .windows.path import add_remove_path
@@ -209,7 +224,6 @@ def execute(args: Namespace) -> None | int:
             )
     else:
         raise NotImplementedError(f"No action available for subcommand '{args.cmd}'.")
-    return action(
-        prefix=Path(args.prefix).expanduser().resolve(),
-        **kwargs,
-    )
+    if args.cmd != "update-bootstrapper":
+        kwargs["prefix"] = Path(args.prefix).expanduser().resolve()
+    return action(**kwargs)

--- a/src/conda_constructor/cli.py
+++ b/src/conda_constructor/cli.py
@@ -150,13 +150,8 @@ def configure_parser(parser: ArgumentParser) -> None:
 
     # Not implemented for onedir builds
     if Path(sys.prefix).name != "_internal":
-        update_subparser = subparsers.add_parser(
+        subparsers.add_parser(
             "update-bootstrapper", description="Updates the conda-standalone binary."
-        )
-        update_subparser.add_argument(
-            "--force",
-            action="store_true",
-            help="Update even if already at the latest version.",
         )
 
     if sys.platform != "win32":

--- a/src/conda_constructor/extract.py
+++ b/src/conda_constructor/extract.py
@@ -6,7 +6,7 @@ from enum import Enum
 from pathlib import Path
 
 from conda.auxlib.type_coercion import boolify
-from conda.base.constants import CONDA_PACKAGE_EXTENSIONS
+from conda.base.context import context
 from conda_package_handling import api
 from conda_package_streaming.package_streaming import TarfileNoSameOwner
 from tqdm.auto import tqdm
@@ -71,7 +71,7 @@ def _extract_conda_pkgs(prefix: Path, max_workers=None) -> None:
     current_location = Path.cwd()
     os.chdir(prefix / "pkgs")
     flist = []
-    for ext in CONDA_PACKAGE_EXTENSIONS:
+    for ext in context.plugin_manager.get_package_extractors():
         for pkg in Path.cwd().iterdir():
             if pkg.name.endswith(ext):
                 flist.append(str(pkg))

--- a/src/conda_constructor/update_bootstrapper.py
+++ b/src/conda_constructor/update_bootstrapper.py
@@ -120,8 +120,9 @@ def update_bootstrapper() -> None:
     with TemporaryDirectory() as tmp_path:
         tmp = Path(tmp_path)
         package = tmp / match.fn
-        if not package.name.lower().endswith((".conda", ".tar.bz2")):
-            raise UpdateError(f"Can't extract unknown package type: '{package.name}'.")
+        valid_suffixes = tuple(context.plugin_manager.get_package_extractors().keys())
+        if not package.name.lower().endswith(valid_suffixes):
+            raise UpdateError(f"Cannot extract unknown package type: '{package.name}'.")
 
         download(match.url, package, sha256=match.sha256)
         cph_api.extract(str(package), dest_dir=str(tmp))

--- a/src/conda_constructor/update_bootstrapper.py
+++ b/src/conda_constructor/update_bootstrapper.py
@@ -29,11 +29,11 @@ class UpdateError(RuntimeError):
 
 def _find_update(min_version: str) -> PackageRecord | None:
     """Find the latest conda-standalone version if older than the current binary."""
-    version = f">{min_version}"
+    version = f">={min_version}"
     spec = MatchSpec(name="conda-standalone", version=version)
     matches = sorted(
         SubdirData.query_all(spec, context.channels, context.subdirs),
-        key=lambda rec: (VersionOrder(rec.version), rec.build),
+        key=lambda rec: (VersionOrder(rec.version), rec.build_number),
         reverse=True,
     )
     if not matches:
@@ -120,8 +120,8 @@ def update_bootstrapper() -> None:
     with TemporaryDirectory() as tmp_path:
         tmp = Path(tmp_path)
         package = tmp / match.fn
-        if package.suffix not in (".conda", ".bz2"):
-            raise UpdateError(f"Cannot extract package of format {package.suffix}.")
+        if not package.name.lower().endswith((".conda", ".tar.bz2")):
+            raise UpdateError(f"Can't extract unknown package type: '{package.name}'.")
 
         download(match.url, package, sha256=match.sha256)
         cph_api.extract(str(package), dest_dir=str(tmp))

--- a/src/conda_constructor/update_bootstrapper.py
+++ b/src/conda_constructor/update_bootstrapper.py
@@ -15,7 +15,7 @@ from conda.models.match_spec import MatchSpec
 from conda.models.version import VersionOrder
 from conda_package_handling import api as cph_api
 
-from conda_constructor._version import __version__
+from conda_constructor._version import __buildnum__, __version__
 
 if TYPE_CHECKING:
     from conda.models.records import PackageRecord
@@ -27,18 +27,28 @@ class UpdateError(RuntimeError):
     pass
 
 
-def _find_update(min_version: str) -> PackageRecord | None:
-    """Find the latest conda-standalone version if older than the current binary."""
-    version = f">={min_version}"
-    spec = MatchSpec(name="conda-standalone", version=version)
-    matches = sorted(
-        SubdirData.query_all(spec, context.channels, context.subdirs),
-        key=lambda rec: (VersionOrder(rec.version), rec.build_number),
-        reverse=True,
+def _find_update(min_version: str, min_buildnum: int) -> PackageRecord | None:
+    """Find the latest conda-standalone version if newer than the current binary."""
+    spec = MatchSpec(name="conda-standalone", version=f">={min_version}")
+    matches = tuple(
+        filter(
+            lambda rec: "_onedir_" not in rec.build,
+            SubdirData.query_all(spec, context.channels, context.subdirs),
+        )
     )
     if not matches:
         return None
-    return matches[0]
+    latest = sorted(
+        matches,
+        key=lambda rec: (VersionOrder(rec.version), rec.build_number),
+        reverse=True,
+    )[0]
+    if (
+        VersionOrder(min_version) == VersionOrder(latest.version)
+        and min_buildnum == latest.build_number
+    ):
+        return None
+    return latest
 
 
 _CLEANUP_SCRIPT = """\
@@ -112,7 +122,7 @@ def update_bootstrapper() -> None:
     os.environ["CONDA_RESTRICT_SEARCH_PATH"] = "1"
     reset_context()
 
-    match = _find_update(__version__)
+    match = _find_update(min_version=__version__, min_buildnum=__buildnum__)
     if match is None:
         print("Already up-to-date.")
         return

--- a/src/conda_constructor/update_bootstrapper.py
+++ b/src/conda_constructor/update_bootstrapper.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING
+
+from conda.base.context import context, reset_context
+from conda.core.subdir_data import SubdirData
+from conda.gateways.connection.download import download
+from conda.models.match_spec import MatchSpec
+from conda.models.version import VersionOrder
+from conda_package_handling import api as cph_api
+
+from conda_constructor._version import __version__
+
+if TYPE_CHECKING:
+    from conda.models.records import PackageRecord
+
+RELOCATED_NAME_SUFFIX = ".__relocated__"
+
+
+class UpdateError(RuntimeError):
+    pass
+
+
+def _find_update(min_version: str) -> PackageRecord | None:
+    version = f">{min_version}"
+    spec = MatchSpec(name="conda-standalone", version=version)
+    matches = sorted(
+        SubdirData.query_all(spec, context.channels, context.subdirs),
+        key=lambda rec: (VersionOrder(rec.version), rec.build),
+        reverse=True,
+    )
+    if not matches:
+        return None
+    return matches[0]
+
+
+_CLEANUP_SCRIPT = """\
+import os
+import time
+
+relocated_exe = r'{relocated_exe}'
+
+for _ in range(600):
+    try:
+        os.remove(relocated_exe)
+    except OSError:
+        time.sleep(0.1)
+    else:
+        break
+"""
+
+
+def _schedule_cleanup_after_exit(
+    executable: Path,
+    relocated_exe: Path,
+) -> None:
+    """Schedule the old binary for deletion.
+
+    Since Windows does not allow deleting files with open file handles,
+    spawn a detached process that waits until the file handle is freed,
+    then delete the relocated file.
+    """
+    script = _CLEANUP_SCRIPT.format(relocated_exe=relocated_exe)
+
+    # Remove PyInstaller-related environment variables or the relocated
+    # executable will inherit them and extract into the same prefix.
+    env = {key: val for key, val in os.environ.items() if not key.startswith("_PYI_")}
+    subprocess.Popen(
+        [executable, "python", "-c", script],
+        creationflags=subprocess.CREATE_NO_WINDOW | subprocess.CREATE_NEW_PROCESS_GROUP,
+        close_fds=True,
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _apply_update(
+    new_conda_exe: Path,
+    conda_exe: Path,
+) -> None:
+    """Update conda.exe in place with rollback on failure."""
+    relocated_exe = conda_exe.with_stem(f"{conda_exe.stem}{RELOCATED_NAME_SUFFIX}")
+    if relocated_exe.exists():
+        relocated_exe.unlink()
+
+    os.rename(conda_exe, relocated_exe)
+    try:
+        shutil.copy2(new_conda_exe, conda_exe)
+    except Exception as exc:
+        os.rename(relocated_exe, conda_exe)
+        os.unlink(new_conda_exe)
+        raise UpdateError(f"Update failed, rolled back to previous version: {exc}") from exc
+
+    if sys.platform == "win32":
+        _schedule_cleanup_after_exit(conda_exe, relocated_exe)
+    else:
+        relocated_exe.unlink()
+
+
+def update_bootstrapper() -> None:
+    # Only use the bundled .condarc file so that conda-standalone
+    # is not downloaded from a different channel
+    os.environ["CONDA_RESTRICT_SEARCH_PATH"] = "1"
+    reset_context()
+
+    match = _find_update(__version__)
+    if match is None:
+        print("Already up-to-date.")
+        return
+
+    with TemporaryDirectory() as tmp_path:
+        tmp = Path(tmp_path)
+        package = tmp / match.fn
+        if package.suffix not in (".conda", ".bz2"):
+            raise UpdateError(f"Cannot extract package of format {package.suffix}.")
+
+        download(match.url, package, sha256=match.sha256)
+        cph_api.extract(str(package), dest_dir=str(tmp))
+        new_conda_exe = tmp / "standalone_conda" / "conda.exe"
+
+        if not new_conda_exe.exists():
+            raise UpdateError(f"Expected executable not found in package: {new_conda_exe}")
+
+        conda_exe = Path(sys.executable)
+        _apply_update(new_conda_exe, conda_exe)
+        print(f"Updated conda-standalone to {match.version} (build {match.build}).")

--- a/src/conda_constructor/update_bootstrapper.py
+++ b/src/conda_constructor/update_bootstrapper.py
@@ -28,6 +28,7 @@ class UpdateError(RuntimeError):
 
 
 def _find_update(min_version: str) -> PackageRecord | None:
+    """Find the latest conda-standalone version if older than the current binary."""
     version = f">{min_version}"
     spec = MatchSpec(name="conda-standalone", version=version)
     matches = sorted(

--- a/tests/test_update_bootstrapper.py
+++ b/tests/test_update_bootstrapper.py
@@ -24,7 +24,6 @@ from utils import run_conda
 if TYPE_CHECKING:
     from pathlib import Path
 
-ON_WIN = sys.platform == "win32"
 if os.environ.get("PYINSTALLER_BUILD_VARIANT") == "onedir":
     pytest.skip("Not implemented for onedir builds.", allow_module_level=True)
 

--- a/tests/test_update_bootstrapper.py
+++ b/tests/test_update_bootstrapper.py
@@ -56,7 +56,7 @@ def _script_find_update():
     os.environ["CONDA_RESTRICT_SEARCH_PATH"] = "1"
     reset_context()
 
-    match = _find_update("1.0.0")
+    match = _find_update("1.0.0", 0)
     assert match is not None
     assert match.name == "conda-standalone"
     print("PASS")
@@ -70,7 +70,115 @@ def _script_find_update_already_up_to_date():
     os.environ["CONDA_RESTRICT_SEARCH_PATH"] = "1"
     reset_context()
 
-    match = _find_update("999.999.999")
+    match = _find_update("999.999.999", 0)
+    assert match is None
+    print("PASS")
+
+
+def _script_find_update_filters_onedir():
+    from unittest.mock import patch
+
+    from conda.models.records import PackageRecord
+
+    from conda_constructor.update_bootstrapper import _find_update
+
+    mock_records = [
+        PackageRecord(
+            name="conda-standalone",
+            version="26.3.2",
+            build="py313_onedir_0",
+            build_number=0,
+        ),
+        PackageRecord(
+            name="conda-standalone",
+            version="26.3.2",
+            build="py313_single_0",
+            build_number=0,
+        ),
+    ]
+
+    with patch("conda.core.subdir_data.SubdirData.query_all", return_value=mock_records):
+        match = _find_update("25.11.1", 0)
+
+    assert match is not None
+    assert "_onedir_" not in match.build
+    assert match.build == "py313_single_0"
+    print("PASS")
+
+
+def _script_find_update_prefers_higher_build_number():
+    from unittest.mock import patch
+
+    from conda.models.records import PackageRecord
+
+    from conda_constructor.update_bootstrapper import _find_update
+
+    mock_records = [
+        PackageRecord(
+            name="conda-standalone",
+            version="26.3.2",
+            build="py313_single_0",
+            build_number=0,
+        ),
+        PackageRecord(
+            name="conda-standalone",
+            version="26.3.2",
+            build="py313_single_1",
+            build_number=1,
+        ),
+    ]
+
+    with patch("conda.core.subdir_data.SubdirData.query_all", return_value=mock_records):
+        match = _find_update("25.11.1", 0)
+
+    assert match is not None
+    assert match.build_number == 1
+    print("PASS")
+
+
+def _script_find_update_same_version_higher_build():
+    from unittest.mock import patch
+
+    from conda.models.records import PackageRecord
+
+    from conda_constructor.update_bootstrapper import _find_update
+
+    mock_records = [
+        PackageRecord(
+            name="conda-standalone",
+            version="26.3.2",
+            build="py313_single_1",
+            build_number=1,
+        ),
+    ]
+
+    with patch("conda.core.subdir_data.SubdirData.query_all", return_value=mock_records):
+        match = _find_update("26.3.2", 0)
+
+    assert match is not None
+    assert match.build_number == 1
+    print("PASS")
+
+
+def _script_find_update_same_version_same_build():
+    from unittest.mock import patch
+
+    from conda.models.records import PackageRecord
+
+    from conda_constructor.update_bootstrapper import _find_update
+
+    mock_records = [
+        PackageRecord(
+            name="conda-standalone",
+            version="26.3.2",
+            build="py313_single_0",
+            build_number=0,
+        ),
+    ]
+
+    with patch("conda.core.subdir_data.SubdirData.query_all", return_value=mock_records):
+        match = _find_update("26.3.2", 0)
+
     assert match is None
     print("PASS")
 
@@ -208,6 +316,34 @@ def test_find_update():
 def test_find_update_already_up_to_date():
     """Test _find_update returns None when already at the latest version."""
     process = _run_script(_script_find_update_already_up_to_date)
+    assert process.returncode == 0
+    assert "PASS" in process.stdout
+
+
+def test_find_update_filters_onedir():
+    """Test _find_update excludes onedir builds."""
+    process = _run_script(_script_find_update_filters_onedir)
+    assert process.returncode == 0
+    assert "PASS" in process.stdout
+
+
+def test_find_update_prefers_higher_build_number():
+    """Test _find_update prefers higher build numbers for same version."""
+    process = _run_script(_script_find_update_prefers_higher_build_number)
+    assert process.returncode == 0
+    assert "PASS" in process.stdout
+
+
+def test_find_update_same_version_higher_build():
+    """Test _find_update returns match when same version but higher build number."""
+    process = _run_script(_script_find_update_same_version_higher_build)
+    assert process.returncode == 0
+    assert "PASS" in process.stdout
+
+
+def test_find_update_same_version_same_build():
+    """Test _find_update returns None when same version and build number."""
+    process = _run_script(_script_find_update_same_version_same_build)
     assert process.returncode == 0
     assert "PASS" in process.stdout
 

--- a/tests/test_update_bootstrapper.py
+++ b/tests/test_update_bootstrapper.py
@@ -1,3 +1,15 @@
+"""Test update-bootstrapper subcommand for the constructor plug-in.
+
+A true integration test would require an updated conda-standalone to be
+available in a channel. If a later version is built and tested, however,
+there is nothing to update to.
+
+Some individual pieces can be tested as unit tests using the built-in
+Python interpreter in conda-standalone, which allows mocking some components.
+Python commands/scripts are written as functions to allow for type checking
+and linting.
+"""
+
 from __future__ import annotations
 
 import inspect

--- a/tests/test_update_bootstrapper.py
+++ b/tests/test_update_bootstrapper.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+from textwrap import dedent
+from typing import TYPE_CHECKING
+
+import pytest
+from utils import run_conda
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+ON_WIN = sys.platform == "win32"
+if os.environ.get("PYINSTALLER_BUILD_VARIANT") == "onedir":
+    pytest.skip("Not implemented for onedir builds.", allow_module_level=True)
+
+
+def _run_script(func, **kwargs):
+    """Run a function as a script inside conda-standalone's Python."""
+    # Remove the function definition line and dedent the body
+    source = inspect.getsourcelines(func)[0][1:]
+    body = dedent("\n".join(source))
+    # Inject kwargs as variables at the top
+    injections = "\n".join(f"{k} = {v!r}" for k, v in kwargs.items())
+    script = f"{injections}\n{body}" if injections else body
+
+    process = run_conda("python", "-c", script, capture_output=True, text=True)
+    print(process.stdout)
+    print(process.stderr, file=sys.stderr)
+    return process
+
+
+# ---------------------------------------------------------------------------
+# Script functions to run inside conda-standalone
+# ---------------------------------------------------------------------------
+
+
+def _script_find_update():
+    from conda.base.context import reset_context
+
+    from conda_constructor.update_bootstrapper import _find_update
+
+    os.environ["CONDA_RESTRICT_SEARCH_PATH"] = "1"
+    reset_context()
+
+    match = _find_update("1.0.0")
+    assert match is not None
+    assert match.name == "conda-standalone"
+    print("PASS")
+
+
+def _script_find_update_already_up_to_date():
+    from conda.base.context import reset_context
+
+    from conda_constructor.update_bootstrapper import _find_update
+
+    os.environ["CONDA_RESTRICT_SEARCH_PATH"] = "1"
+    reset_context()
+
+    match = _find_update("999.999.999")
+    assert match is None
+    print("PASS")
+
+
+def _script_apply_update(prefix_str: str, conda_exe: str):
+    import subprocess
+    import sys
+    import time
+    from pathlib import Path
+
+    from conda_constructor.update_bootstrapper import RELOCATED_NAME_SUFFIX, _apply_update
+
+    prefix = Path(prefix_str)
+    old_exe = prefix / "old_conda.exe"
+    new_exe = Path(conda_exe)
+
+    old_exe.write_text("old content")
+
+    original_popen = subprocess.Popen
+
+    def patched_popen(args, _conda_exe=conda_exe, _original_popen=original_popen, **kwargs):
+        # Replace the fake executable with the real conda-standalone
+        args = [_conda_exe] + args[1:]
+        return _original_popen(args, **kwargs)
+
+    # Patch Popen to use real conda-standalone for cleanup subprocess
+    subprocess.Popen = patched_popen
+    try:
+        _apply_update(new_exe, old_exe)
+    finally:
+        subprocess.Popen = original_popen
+
+    # Verify update succeeded
+    assert old_exe.read_bytes() == new_exe.read_bytes()
+
+    relocated = old_exe.with_stem(f"{old_exe.stem}{RELOCATED_NAME_SUFFIX}")
+    if sys.platform == "win32":
+        for _ in range(600):
+            if not relocated.exists():
+                break
+            time.sleep(0.1)
+    assert not relocated.exists()
+    print("PASS")
+
+
+def _script_apply_update_rollback(prefix_str: str):
+    import sys
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from conda_constructor.update_bootstrapper import UpdateError, _apply_update
+
+    prefix = Path(prefix_str)
+    old_exe = prefix / "old_conda.exe"
+    new_exe_parent = prefix / "new_standalone"
+    new_exe = new_exe_parent / "conda.exe"
+
+    old_exe.write_text("old content")
+    new_exe_parent.mkdir()
+    new_exe.write_text("new content")
+
+    with patch("shutil.copy2", side_effect=OSError("Copy failed")):
+        try:
+            _apply_update(new_exe, old_exe)
+            print("FAIL: should have raised")
+            sys.exit(1)
+        except UpdateError as e:
+            if "rolled back" not in str(e):
+                print(f"FAIL: wrong message: {e}")
+                sys.exit(1)
+
+    assert old_exe.read_text() == "old content"
+    print("PASS")
+
+
+def _script_apply_update_cleans_stale(prefix_str: str, conda_exe: str):
+    import subprocess
+    import sys
+    import time
+    from pathlib import Path
+
+    from conda_constructor.update_bootstrapper import RELOCATED_NAME_SUFFIX, _apply_update
+
+    prefix = Path(prefix_str)
+    old_exe = prefix / "old_conda.exe"
+    new_exe = Path(conda_exe)
+    stale_relocated = old_exe.with_stem(f"{old_exe.stem}{RELOCATED_NAME_SUFFIX}")
+
+    old_exe.write_text("old content")
+    stale_relocated.write_text("stale content")
+
+    original_popen = subprocess.Popen
+
+    def patched_popen(args, _conda_exe=conda_exe, _original_popen=original_popen, **kwargs):
+        # Replace the fake executable with the real conda-standalone
+        args = [_conda_exe] + args[1:]
+        return _original_popen(args, **kwargs)
+
+    # Patch Popen to use real conda-standalone for cleanup subprocess
+    subprocess.Popen = patched_popen
+    try:
+        _apply_update(new_exe, old_exe)
+    finally:
+        subprocess.Popen = original_popen
+
+    # Verify update succeeded
+    assert old_exe.read_bytes() == new_exe.read_bytes()
+
+    relocated = old_exe.with_stem(f"{old_exe.stem}{RELOCATED_NAME_SUFFIX}")
+    if sys.platform == "win32":
+        for _ in range(600):
+            if not relocated.exists():
+                break
+            time.sleep(0.1)
+    assert not relocated.exists()
+    print("PASS")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_update_bootstrapper_help():
+    run_conda("constructor", "update-bootstrapper", "--help", check=True)
+
+
+def test_find_update():
+    """Test _find_update finds a newer version when one exists."""
+    process = _run_script(_script_find_update)
+    assert process.returncode == 0
+    assert "PASS" in process.stdout
+
+
+def test_find_update_already_up_to_date():
+    """Test _find_update returns None when already at the latest version."""
+    process = _run_script(_script_find_update_already_up_to_date)
+    assert process.returncode == 0
+    assert "PASS" in process.stdout
+
+
+def test_apply_update(tmp_path: Path):
+    """Test _apply_update replaces the executable and cleans up."""
+    from utils import CONDA_EXE
+
+    process = _run_script(_script_apply_update, prefix_str=str(tmp_path), conda_exe=CONDA_EXE)
+    assert process.returncode == 0
+    assert "PASS" in process.stdout
+
+
+def test_apply_update_rollback_on_failure(tmp_path: Path):
+    """Test _apply_update rolls back on copy failure."""
+    process = _run_script(_script_apply_update_rollback, prefix_str=str(tmp_path))
+    assert process.returncode == 0
+    assert "PASS" in process.stdout
+
+
+def test_apply_update_cleans_stale_relocated(tmp_path: Path):
+    """Test _apply_update removes stale relocated files before updating."""
+    from utils import CONDA_EXE
+
+    process = _run_script(
+        _script_apply_update_cleans_stale, prefix_str=str(tmp_path), conda_exe=CONDA_EXE
+    )
+    assert process.returncode == 0
+    assert "PASS" in process.stdout


### PR DESCRIPTION
### Description

Provide a way for `conda-standalone` to self-update. The uninstallation subcommand in the `constructor` plug-in relies on `conda` maintaining a forwards-compatible API. With the recent publication of `conda-pypi`, this is no longer the case: a wheel installed into an environment will lead to errors in older conda(-standalone) versions.

To ensure that uninstallations do not fail, it may be necessary in the future to update the `conda-standalone` bootstrapper. #264 has already inquired about a procedure to do so. This PR implements this feature by checking for the latest version in the channel given in the `.condarc` file delivered with `conda-standalone`.

Since on Windows, a file with an open file handle cannot be overwritten, the binary is renamed first - deletion of the renamed file is delegated to a detached process.

This is only implemented for single-binary builds because I have not found a way to make this work for `onedir` builds because the execution requires the `_internal` directory or the binary entry point to not be moved or the program will crash. Delegating the moving to a detached process will lead to a race condition if `conda-standalone` is called immediately afterwards. I have not found a way to create a blocked process that frees the file handles.

I also noticed that `CONDA_PACKAGE_EXTENSIONS` are soon to be deprecated, so I replaced those already.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-standalone/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?