### PR TITLE
Set version of the build dependency specifying the C standard library

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,4 +6,4 @@ c_stdlib:
   - macosx_deployment_target   # [osx]
   - vs                         # [win]
 c_stdlib_version:              # [linux]
-  - "2.28"                     # [linux]
+  - "2.17"                     # [linux]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,3 +5,5 @@ c_stdlib:
   - sysroot                    # [linux]
   - macosx_deployment_target   # [osx]
   - vs                         # [win]
+c_stdlib_version:              # [linux]
+  - "2.28"                     # [linux]


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
Specify GLIBC version to improve compliance with `conda-build` - the hypothesis is that `conda-build` uses system GLIBC if not specified. This is primarily for canary builds where we discovered that the bundled version of `conda-standalone` as is right now depends on GLIBC `2.35` which is fairly strict, but this change will improve the compliance.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-standalone/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-standalone/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-standalone/blob/main/CONTRIBUTING.md -->
