### PR TITLE
Bump dependencies for conda 26.5.3

### DIFF
--- a/news/286-new-dependencies
+++ b/news/286-new-dependencies
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Update `conda` to `26.5.3`, `libmambapy` to `2.8.1`, and minimum version of `constructor` to `3.15.3`. (#286)
+* Update `conda` to `26.5.3` and minimum version of `constructor` to `3.15.3`. (#286)
 
 ### Bug fixes
 

--- a/news/286-new-dependencies
+++ b/news/286-new-dependencies
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Update `conda` to `26.5.3`, `libmambapy` to `2.8.1`, and minimum version of `constructor` to `3.15.3`. (#286)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
-{% set conda_version = "26.5.2" %}
+{% set conda_version = "26.5.3" %}
 {% set conda_libmamba_solver_version = "26.4.2" %}
-{% set libmambapy_version = "2.8.0" %}
-{% set constructor_lower_bound = "3.15.2" %}
+{% set libmambapy_version = "2.8.1" %}
+{% set constructor_lower_bound = "3.15.3" %}
 {% set menuinst_lower_bound = "2.5.0" %}
 {% set python_version = "3.13.13" %}
 {% set pyver = "".join(python_version.split(".")[:2]) %}
@@ -14,7 +14,7 @@ source:
   - path: ../
 
   - url: https://github.com/conda/conda/releases/download/{{ conda_version }}/conda-{{ conda_version }}.tar.gz
-    sha256: 4c0227d37f7a54b332fea5b12ba855252ca80fbc1452bb66522eb74084039be5
+    sha256: 473f8e8366bba2b4672cc5e350b66604f253541f11c40218a1a1a859527c3592
     folder: conda_src
     # NOTE: All files affected by a patch need to be manually copied
     # from src to PREFIX in build.sh and bld.bat

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set conda_version = "26.5.3" %}
 {% set conda_libmamba_solver_version = "26.4.2" %}
-{% set libmambapy_version = "2.8.1" %}
+{% set libmambapy_version = "2.8.0" %}
 {% set constructor_lower_bound = "3.15.3" %}
 {% set menuinst_lower_bound = "2.5.0" %}
 {% set python_version = "3.13.13" %}


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR bumps the version of `conda` and minimum `constructor` version.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-standalone/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-standalone/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-standalone/blob/main/CONTRIBUTING.md -->
