### PR TITLE
Ship menuinst macOS launcher templates unmodified (fix missing /usr/lib/swift rpath on x86_64)

### DIFF
--- a/news/291-fix-menuinst-launcher-rpath
+++ b/news/291-fix-menuinst-launcher-rpath
@@ -1,0 +1,23 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Ship the menuinst macOS launcher templates byte-for-byte instead of letting
+  PyInstaller rewrite their load commands. PyInstaller's binary processing
+  removed the `/usr/lib/swift` rpath from `appkit_launcher_*`, so shortcuts
+  created by conda-standalone failed to launch on x86_64 with
+  `Library not loaded: @rpath/libswiftCore.dylib`. (conda/menuinst#507)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/src/conda.exe.spec
+++ b/src/conda.exe.spec
@@ -158,6 +158,32 @@ a = Analysis(['entry_point.py'],
              win_private_assemblies=False,
              cipher=block_cipher,
              noarchive=False)
+
+if sys.platform == "darwin":
+    # PyInstaller >= 6 re-classifies the menuinst launcher templates collected
+    # above (via get_menuinst_data_files()) from DATA to BINARY, because they
+    # are Mach-O executables. Binary processing then rewrites their load
+    # commands: all existing rpaths are removed and a bundle-relative rpath
+    # (@loader_path/../..) is added. This strips /usr/lib/swift from
+    # appkit_launcher_*, which links the Swift runtime via @rpath, so shortcuts
+    # deployed from the frozen menuinst fail to launch on x86_64 with
+    # "Library not loaded: @rpath/libswiftCore.dylib" (arm64 is unaffected
+    # because dyld resolves the Swift runtime from the shared cache).
+    # See conda/menuinst#507 and napari/packaging#401.
+    #
+    # These launchers are never loaded by conda.exe itself: they are templates
+    # that menuinst copies into shortcut .app bundles and re-signs afterwards.
+    # Move them back to DATA so they are shipped byte-for-byte. Analysis trusts
+    # typecodes modified after it ran, so they undergo no further processing.
+    launchers = [
+        (dest_name, src_name, "DATA")
+        for dest_name, src_name, typecode in a.binaries
+        if os.path.basename(dest_name).startswith(("osx_launcher_", "appkit_launcher_"))
+    ]
+    launcher_dests = {dest_name for dest_name, _, _ in launchers}
+    a.binaries = [entry for entry in a.binaries if entry[0] not in launcher_dests]
+    a.datas.extend(launchers)
+
 pyz = PYZ(a.pure, a.zipped_data,
              cipher=block_cipher)
 

--- a/tests/test_menuinst.py
+++ b/tests/test_menuinst.py
@@ -77,3 +77,34 @@ def test_menuinst_conda_standalone(
         if any(shortcut.exists() for shortcut in shortcuts)
     ]
     assert shortcuts_found == []
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS only")
+def test_macos_launchers_shipped_unmodified(tmp_path: Path):
+    """
+    The frozen menuinst launcher templates must keep their original load
+    commands. PyInstaller's binary processing used to rewrite their rpaths,
+    stripping /usr/lib/swift from appkit_launcher_*, which broke Swift
+    runtime resolution on x86_64 (conda/menuinst#507).
+    """
+    script = (
+        "import glob, os, shutil, sys, menuinst; "
+        "data_dir = os.path.join(os.path.dirname(menuinst.__file__), 'data'); "
+        "[shutil.copy(path, sys.argv[1]) "
+        "for path in glob.glob(os.path.join(data_dir, 'appkit_launcher_*'))]"
+    )
+    run_conda(
+        "python",
+        "-c",
+        script,
+        str(tmp_path),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    launchers = list(tmp_path.glob("appkit_launcher_*"))
+    assert launchers, "no appkit launcher templates found in frozen menuinst"
+    for launcher in launchers:
+        assert b"/usr/lib/swift" in launcher.read_bytes(), (
+            f"{launcher.name} lost its /usr/lib/swift rpath"
+        )


### PR DESCRIPTION
### Description

macOS shortcuts created by conda-standalone fail to launch on x86_64 with:

```
dyld: Library not loaded: @rpath/libswiftCore.dylib
```

This is the conda-standalone side of conda/menuinst#507 (original report: napari/packaging#401, affecting the napari 0.7.0/0.7.1 Intel installers).

**Root cause.** `conda.exe.spec` collects the menuinst launcher templates as `datas`, but PyInstaller ≥ 6 re-classifies them as BINARY entries because they are Mach-O executables (`build_main.py`, "binary vs. data reclassification"). Binary processing then rewrites their load commands ([`osx.py::set_dylib_dependency_paths`](https://github.com/pyinstaller/pyinstaller/blob/v6.21.0/PyInstaller/utils/osx.py#L437-L441)): *"remove any existing rpaths (LC_RPATH commands), and add a new rpath"* — the bundle-relative `@loader_path/../..`. The `/usr/lib/swift` rpath that `appkit_launcher_x86_64` needs to locate the Swift runtime is lost:

| `appkit_launcher_x86_64` | `LC_RPATH` |
|---|---|
| menuinst 2.5.1 package | `/usr/lib/swift`, `@loader_path`, (Xcode toolchain) |
| same file frozen in `conda-standalone-26.5.2-h8b077d2_1` | `@loader_path/../..` only |

arm64 is unaffected for two independent reasons: dyld resolves the Swift runtime from the shared cache without the rpath, and `appkit_launcher_arm64` links Swift via absolute `/usr/lib/swift/...` paths (exempted from rewrite as system paths), so the breakage only shows on Intel.

**Fix.** The launchers are never loaded by `conda.exe` itself — they are templates that menuinst copies into shortcut `.app` bundles and re-signs afterwards (`menuinst/platforms/osx.py`), so they must be shipped byte-for-byte. Move their TOC entries back to DATA after `Analysis` runs; Analysis explicitly trusts typecodes modified after it ran, and DATA entries bypass binary processing entirely (executable bits are preserved, and menuinst `chmod`s the copy anyway).

Side effects considered:
- *Signing*: PyInstaller no longer ad-hoc-signs the templates, but menuinst re-signs the deployed `.app` (`codesign --sign - --force --deep`), which is the only place a signature matters.
- *Dependency analysis*: the launchers link only system libraries (`/usr/lib/swift`, Foundation, AppKit), which PyInstaller never bundles, so nothing is lost by skipping the scan.

### Verification

- Minimal PyInstaller 6.21.0 repro (x86_64 Python, collecting `appkit_launcher_x86_64` from the published menuinst 2.5.1 package): without this change the frozen launcher has `LC_RPATH = @loader_path/../..` only; with it, the launcher is byte-identical to the source (`cmp` passes), keeping `/usr/lib/swift`.
- On-hardware (Intel Mac, macOS 13.7.8): a napari 0.7.1 installer built with `conda-standalone-26.5.2-h8b077d2_1` deploys a launcher that aborts with `Library not loaded: @rpath/libswiftCore.dylib`; manually re-adding the `/usr/lib/swift` rpath to that launcher (`install_name_tool -add_rpath` + ad-hoc re-sign) makes the app launch. Details in napari/packaging#401.

A regression test is included: it extracts the frozen `appkit_launcher_*` templates via `conda.exe python` and asserts `/usr/lib/swift` is still present in the binary.

xref: conda/menuinst#507, conda-forge/menuinst-feedstock#62 (fixed the same stripping done by conda-build relocation at the package level), napari/packaging#401

### Checklist

- [x] Added a `news` entry
- [x] Added / updated tests
